### PR TITLE
feat: Customise constraints

### DIFF
--- a/config/level-up.php
+++ b/config/level-up.php
@@ -12,6 +12,7 @@ return [
     'user' => [
         'foreign_key' => 'user_id',
         'model' => App\Models\User::class,
+        'users_table' => 'users',
     ],
 
     /*

--- a/database/migrations/create_achievement_user_pivot_table.php.stub
+++ b/database/migrations/create_achievement_user_pivot_table.php.stub
@@ -9,7 +9,7 @@ return new class extends Migration {
     {
         Schema::create('achievement_user', function (Blueprint $table) {
             $table->id();
-            $table->foreignId(column: 'user_id')->constrained();
+            $table->foreignId(column: config('level-up.user.foreign_key'))->constrained(config('level-up.user.users_table'));
             $table->foreignId(column: 'achievement_id')->constrained();
             $table->integer(column: 'progress')->nullable()->index();
             $table->timestamps();

--- a/database/migrations/create_experience_audits_table.php.stub
+++ b/database/migrations/create_experience_audits_table.php.stub
@@ -9,7 +9,7 @@ return new class extends Migration {
     {
         Schema::create('experience_audits', function (Blueprint $table) {
             $table->id();
-            $table->foreignId(config('level-up.user.foreign_key'))->constrained('users');
+            $table->foreignId(config('level-up.user.foreign_key'))->constrained(config('level-up.user.users_table'));
             $table->integer('points')->index();
             $table->boolean('levelled_up')->default(false);
             $table->integer('level_to')->nullable();

--- a/database/migrations/create_experiences_table.php.stub
+++ b/database/migrations/create_experiences_table.php.stub
@@ -10,7 +10,7 @@ return new class extends Migration
     {
         Schema::create(config('level-up.table'), function (Blueprint $table) {
             $table->id();
-            $table->foreignId(config('level-up.user.foreign_key'))->constrained('users');
+            $table->foreignId(config('level-up.user.foreign_key'))->constrained(config('level-up.user.users_table'));
             $table->foreignId('level_id')->constrained();
             $table->integer('experience_points')->default(0)->index();
             $table->timestamps();


### PR DESCRIPTION
This PR adds more customisations to the constraints in the migrations, so for those who aren't always using a `users` table, can benefit.

Closes #11
Closes #12 