### PR TITLE
Adding configurable user's table to level relationship migration.

### DIFF
--- a/database/migrations/add_level_relationship_to_users_table.php.stub
+++ b/database/migrations/add_level_relationship_to_users_table.php.stub
@@ -7,7 +7,7 @@ use Illuminate\Support\Facades\Schema;
 return new class extends Migration {
     public function up(): void
     {
-        Schema::table('users', function (Blueprint $table) {
+        Schema::table(config('level-up.user.users_table'), function (Blueprint $table) {
             $table->foreignId('level_id')
                 ->after('remember_token')
                 ->nullable()
@@ -17,7 +17,7 @@ return new class extends Migration {
 
     public function down(): void
     {
-        Schema::table('users', function (Blueprint $table) {
+        Schema::table(config('level-up.user.users_table'), function (Blueprint $table) {
             $table->dropConstrainedForeignId('level_id');
         });
     }


### PR DESCRIPTION
Found this one was missing the configuration when I reset my dev and re-ran migrations.