### PR TITLE
Implement Titles for Levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/cjmellor/level-up?color=rgb%2856%20189%20248%29&label=release&style=for-the-badge)](https://packagist.org/packages/cjmellor/level-up)
 [![GitHub Tests Action Status](https://img.shields.io/github/actions/workflow/status/cjmellor/level-up/run-tests.yml?branch=main&label=tests&style=for-the-badge&color=rgb%28134%20239%20128%29)](https://github.com/cjmellor/level-up/actions?query=workflow%3Arun-tests+branch%3Amain)
 [![Total Downloads](https://img.shields.io/packagist/dt/cjmellor/level-up.svg?color=rgb%28249%20115%2022%29&style=for-the-badge)](https://packagist.org/packages/cjmellor/level-up)
@@ -110,7 +111,7 @@ return [
 
 # Usage
 
-## 💯 Experience Points (XP)
+## 💯 Experience Points (XP)
 
 > **Note**
 > 
@@ -262,7 +263,7 @@ public int $pointsDecreasedBy,
 public int $totalPoints,
 ```
 
-## ⬆️ Levelling
+## ⬆️ Levelling
 
 > **Note**
 > 
@@ -274,13 +275,13 @@ The package has a handy facade to help you create your levels.
 
 ```php
 Level::add(
-    ['level' => 1, 'next_level_experience' => null],
+    ['level' => 1, 'next_level_experience' => null, 'title' => 'Beginner'],
     ['level' => 2, 'next_level_experience' => 100],
     ['level' => 3, 'next_level_experience' => 250],
 );
 ```
 
-**Level 1** should always be `null` for the `next_level_experience` as it is the default starting point.
+**Level 1** should always be `null` for the `next_level_experience` as it is the default starting point. The '**title**' key is optional.
 
 As soon as a User gains the correct number of points listed for the next level, they will level-up.
 
@@ -296,6 +297,11 @@ $user->nextLevelAt();
 
 ```php
 $user->getLevel();
+```
+**Get the Title for the Users’ current Level**
+
+```php
+$user->getLevelTitle();
 ```
 
 ### Level Cap
@@ -319,7 +325,7 @@ public Model $user,
 public int $level
 ```
 
-## 🏆 Achievements
+## 🏆 Achievements
 
 This is a feature that allows you to recognise and reward users for completing specific tasks or reaching certain milestones.
 You can define your own achievements and criteria for earning them.
@@ -458,7 +464,7 @@ public Model $user,
 public int $amount,
 ```
 
-## 📈 Leaderboard
+## 📈 Leaderboard
 
 The package also includes a leaderboard feature to track and display user rankings based on their experience points.
 
@@ -473,7 +479,7 @@ This generates a User model along with its Experience and Level data and ordered
 > The Leaderboard is very basic and has room for improvement
 >
 
-## 🔍 Auditing
+## 🔍 Auditing
 
 You can enable an Auditing feature in the config, which keeps a track each time a User gains points, levels up and what level to.
 

--- a/database/migrations/add_title_to_levels_table.php.stub
+++ b/database/migrations/add_title_to_levels_table.php.stub
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('levels', function (Blueprint $table) {
+            $table->string('title')
+                ->after('level')
+                ->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('levels', function (Blueprint $table) {
+            $table->dropColumn('title');
+        });
+    }
+};

--- a/src/Concerns/GiveExperience.php
+++ b/src/Concerns/GiveExperience.php
@@ -103,6 +103,11 @@ trait GiveExperience
         return $this->experience->status->level;
     }
 
+    public function getLevelTitle(): ?string
+    {
+        return $this->experience->status->title;
+    }
+
     public function deductPoints(int $amount): Experience
     {
         $this->experience->decrement(column: 'experience_points', amount: $amount);

--- a/src/LevelUpServiceProvider.php
+++ b/src/LevelUpServiceProvider.php
@@ -24,6 +24,7 @@ class LevelUpServiceProvider extends PackageServiceProvider
                 'create_experience_audits_table',
                 'create_achievements_table',
                 'create_achievement_user_pivot_table',
+                'add_title_to_levels_table',
             ]);
     }
 

--- a/src/Models/Level.php
+++ b/src/Models/Level.php
@@ -22,7 +22,8 @@ class Level extends Model
             if (is_array($level)) {
                 $levelNumber = $level['level'];
                 $pointsToNextLevel = $level['next_level_experience'];
-                $title = $level['title'] ?? null;
+                $title = array_key_exists('title', $level) ? level['title'] : null;
+                
             } else {
                 $levelNumber = $level;
                 $pointsToNextLevel = $levels[1] ?? 0;

--- a/src/Models/Level.php
+++ b/src/Models/Level.php
@@ -22,7 +22,7 @@ class Level extends Model
             if (is_array($level)) {
                 $levelNumber = $level['level'];
                 $pointsToNextLevel = $level['next_level_experience'];
-                $title = array_key_exists('title', $level) ? level['title'] : null;
+                $title = array_key_exists('title', $level) ? $level['title'] : null;
                 
             } else {
                 $levelNumber = $level;

--- a/src/Models/Level.php
+++ b/src/Models/Level.php
@@ -22,15 +22,18 @@ class Level extends Model
             if (is_array($level)) {
                 $levelNumber = $level['level'];
                 $pointsToNextLevel = $level['next_level_experience'];
+                $title = $level['title'] ?? null;
             } else {
                 $levelNumber = $level;
                 $pointsToNextLevel = $levels[1] ?? 0;
+                $title = $levels[2] ?? null;
             }
 
             try {
                 $newLevels[] = self::create([
                     'level' => $levelNumber,
                     'next_level_experience' => $pointsToNextLevel,
+                    'title' => $title,
                 ]);
             } catch (Throwable) {
                 throw LevelExistsException::handle(levelNumber: $levelNumber);

--- a/tests/Models/LevelTest.php
+++ b/tests/Models/LevelTest.php
@@ -5,7 +5,7 @@ use LevelUp\Experience\Models\Level;
 
 uses()->group('levels');
 
-it(description: 'can create a level', closure: function (): void {
+it(description: 'can create a level without a title', closure: function (): void {
     $level = Level::add([
         'level' => 4,
         'next_level_experience' => 500,
@@ -16,6 +16,23 @@ it(description: 'can create a level', closure: function (): void {
     $this->assertDatabaseHas(table: 'levels', data: [
         'level' => 4,
         'next_level_experience' => 500,
+        'title' => null,
+    ]);
+});
+
+it(description: 'can create a level with a title', closure: function (): void {
+    $level = Level::add([
+        'level' => 4,
+        'next_level_experience' => 500,
+        'title' => 'Monkey Juggler',
+    ]);
+
+    expect(value: $level[0]->level)->toBe(expected: 4);
+
+    $this->assertDatabaseHas(table: 'levels', data: [
+        'level' => 4,
+        'next_level_experience' => 500,
+        'title' => 'Monkey Juggler',
     ]);
 });
 


### PR DESCRIPTION
This PR implements Titles for levels. This is an optional feature that users of the package can utilize to give titles to their levels.

Levels can have a title or have null for a title. When creating a level, the title can be specified or left as a blank key.

The title of user's current level can be retrieved by calling $user->getLevelTitle();