### PR TITLE
fix: Return correct value on next level check

### DIFF
--- a/src/Concerns/GiveExperience.php
+++ b/src/Concerns/GiveExperience.php
@@ -139,7 +139,7 @@ trait GiveExperience
     {
         $nextLevel = Level::firstWhere(column: 'level', operator: '=', value: $checkAgainst ?? $this->getLevel() + 1);
 
-        if ($nextLevel && $nextLevel->next_level_experience === null) {
+        if (! $nextLevel || $nextLevel->next_level_experience === null) {
             return 0;
         }
 

--- a/tests/Concerns/GiveExperienceTest.php
+++ b/tests/Concerns/GiveExperienceTest.php
@@ -147,6 +147,17 @@ test('a User can see how many more points are needed until they can level up', c
         ->toBe(expected: 99);
 });
 
+it(description: 'returns zero when User has hit Level cap and tries to see how many points until next level', closure: function () {
+    config()->set(key: 'level-up.level_cap.enabled', value: true);
+    config()->set(key: 'level-up.level_cap.level', value: 3);
+
+    $this->user->addPoints(amount: 250);
+
+    expect($this->user)
+        ->nextLevelAt()
+        ->toBe(expected: 0);
+});
+
 test(description: 'when a User hits the next level threshold, their level will increase to the correct level', closure: function (): void {
     Event::fake([UserLevelledUp::class]);
 

--- a/tests/Listeners/PointsIncreasedListenerTest.php
+++ b/tests/Listeners/PointsIncreasedListenerTest.php
@@ -68,10 +68,17 @@ test(description: 'when a User levels up, a record is stored in the audit', clos
 
 test(description: 'user levels are correct', closure: function () {
     $this->user->addPoints(amount: 100);
+
     expect($this->user->getLevel())->toBe(expected: 2)
         ->and($this->user->level_id)->toBe(expected: 2)
         ->and($this->user->nextLevelAt())->toBe(expected: 150)
         ->and($this->user->experience->status->level)->toBe(expected: 2);
+
+    $this->assertDatabaseHas(table: 'experiences', data: [
+        'user_id' => $this->user->id,
+        'experience_points' => 100,
+        'level_id' => 2,
+    ]);
 
     $this->user->addPoints(amount: 150);
 


### PR DESCRIPTION
This PR fixes an issue where when a User has hit the level cap and you try to view the amount of points until the next level, it won't throw an error.

Also added some more assertions.

Fixes #20