### PR TITLE
fix: set timestamps when creating achievements

### DIFF
--- a/src/Concerns/HasAchievements.php
+++ b/src/Concerns/HasAchievements.php
@@ -34,6 +34,7 @@ trait HasAchievements
     public function achievements(): BelongsToMany
     {
         return $this->belongsToMany(related: Achievement::class)
+            ->withTimestamps()
             ->withPivot(columns: 'progress')
             ->where('is_secret', false)
             ->using(AchievementUser::class);


### PR DESCRIPTION
Achievements are being created with null timestamps because a call to the method withTimestamps is needed https://laravel.com/docs/10.x/eloquent-relationships#retrieving-intermediate-table-columns