### PR TITLE
Streaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ return [
 ## 💯 Experience Points (XP)
 
 > **Note**
-> 
+>
 > XP is enabled by default. You can disable it in the config
 
 Add the `GiveExperience` trait to your `User` model.
@@ -138,7 +138,7 @@ $user->addPoints(10);
 A new record will be added to the `experiences` table which stores the Users’ points. If a record already exists, it will be updated instead. All new records will be given a `level_id` of `1`.
 
 > **Note**
-> 
+>
 > If you didn't set up your Level structure yet, a default Level of `1` will be added to get you started.
 
 **Deduct XP points from a User**
@@ -265,7 +265,7 @@ public int $totalPoints,
 ## ⬆️ Levelling
 
 > **Note**
-> 
+>
 > If you add points before setting up your levelling structure, a default Level of `1` will be added to get you started.
 
 ### Set up your levelling structure
@@ -300,7 +300,8 @@ $user->getLevel();
 
 ### Level Cap
 
-A level cap sets the maximum level that a user can reach. Once a user reaches the level cap, they will not be able to gain any more levels, even if they continue to earn experience points. The level cap is enabled by default and capped to level `100`. These options can be changed in the packages config file at `config/level-up.php` or by adding them to your `.env` file.
+A level cap sets the maximum level that a user can reach. Once a user reaches the level cap, they will not be able to gain any more levels, even if they continue to earn experience points. The level cap is enabled by default and capped to level `100`. These
+options can be changed in the packages config file at `config/level-up.php` or by adding them to your `.env` file.
 
 ```
 LEVEL_CAP_ENABLED=
@@ -381,7 +382,7 @@ $user->grantAchievement(
 ```
 
 > **Note**
-> 
+>
 > Achievement progress is capped to 100%
 
 ### Check Achievement Progression
@@ -447,7 +448,7 @@ public Model $user,
 ```
 
 > **Note**
-> 
+>
 > This event only runs if the progress of the Achievement is 100%
 
 **AchievementProgressionIncreased** - When a Users’ progression for an Achievement is increased.
@@ -492,6 +493,102 @@ $user->addPoints(
 
 ```php
 $user->experienceHistory;
+```
+
+## 🔥 Streaks
+
+With the Streaks feature, you can track and motivate user engagement by monitoring consecutive daily activities. Whether it's logging in, completing tasks, or any other daily activity, maintaining streaks encourages users to stay active and engaged.
+
+Streaks are controlled in a Trait, so only use the trait if you want to use this feature. Add the Trait to you `User` model
+
+```php
+use LevelUp\Experience\Concerns\HasStreaks;
+
+class User extends Model
+{
+	use HasStreaks;
+
+	// ...
+}
+```
+
+### Activities
+
+Use the `Activies` model to add new activities that you want to track. Here’s some examples:
+
+- Logs into a website
+- Posts an article
+
+### Record a Streak
+
+```php
+$activity = Activity::find(1);
+
+$user->recordStreak($activity);
+```
+
+This will increment the streak count for the User on this activity. An `Event is ran on increment.
+
+### Break a Streak
+
+Streaks can be broken, both automatically and manually. This puts the count back to `1` to start again. An Event is ran when a streak is broken.
+
+For example, if your streak has had a successful run of 5 days, but a day is skipped and you run the activity on day 7, the streak will be broken and reset back to `1`. Currently, this happens automatically.
+
+### Reset a Streak
+
+You can reset a streak manually if you desire. If `level-up.archive_streak_history.enabled` is true, the streak history will be recorded.
+
+```php
+$activity = Activity::find(1);
+
+$user->resetStreak($activity);
+```
+
+### Archive Streak Histories
+
+Streaks are recorded, or “archived” by default. When a streak is broken, a record of the streak is recorded. A Model is supplied to use this data.
+
+```php
+use LevelUp\Experience\Models\StreakHistory;
+
+StreakHistory::all();
+```
+
+### Get Current Streak Count
+
+See the streak count for an activity for a User
+
+```php
+$user->getCurrentStreakCount($activity); // 2
+```
+
+### Check User Streak Activity
+
+Check if the User has performed a streak for the day
+
+```php
+$user->hasStreakToday($activity);
+```
+
+### Events
+
+**StreakIncreased** - If an activity happens on a day after the previous day, the streak is increased.
+
+```php
+public int $pointsAdded,
+public int $totalPoints,
+public string $type,
+public ?string $reason,
+public Model $user,
+```
+
+**StreakBroken** - When a streak is broken and the counter is reset.
+
+```php
+public Model $user,
+public Activity $activity,
+public Streak $streak,
 ```
 
 # Testing

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,11 @@
+# Ugrade Guide
+
+## v0.0.6 -> v0.0.7
+
+v0.0.7 comes with a brand-new feature -- Streaks.
+
+Some new configuration settings have been introduced. Delete the `config/level-up.php` file.
+
+Now run `php artisan vendor:publish` and select `LevelUp\Experience\LevelUpServiceProvider`
+
+This also publishes new migration files. Run `php artisan migrate` to migrate the new tables.

--- a/composer.json
+++ b/composer.json
@@ -32,8 +32,7 @@
         "pestphp/pest-plugin-laravel": "^2.0",
         "pestphp/pest-plugin-type-coverage": "^2.0",
         "plannr/laravel-fast-refresh-database": "^1.0.2",
-        "rector/rector": "^0.17.6",
-        "spatie/pest-plugin-test-time": "^2.0"
+        "rector/rector": "^0.17.6"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
         "pestphp/pest": "^2.6.1",
         "pestphp/pest-plugin-arch": "^v2.0.2",
         "pestphp/pest-plugin-laravel": "^2.0",
+        "pestphp/pest-plugin-type-coverage": "^2.0",
         "plannr/laravel-fast-refresh-database": "^1.0.2",
         "rector/rector": "^0.17.6"
     },

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,8 @@
         "pestphp/pest-plugin-laravel": "^2.0",
         "pestphp/pest-plugin-type-coverage": "^2.0",
         "plannr/laravel-fast-refresh-database": "^1.0.2",
-        "rector/rector": "^0.17.6"
+        "rector/rector": "^0.17.6",
+        "spatie/pest-plugin-test-time": "^2.0"
     },
     "autoload": {
         "psr-4": {

--- a/config/level-up.php
+++ b/config/level-up.php
@@ -74,4 +74,16 @@ return [
     'audit' => [
         'enabled' => env(key: 'AUDIT_POINTS', default: false),
     ],
+
+    /*
+    | -------------------------------------------------------------------------
+    | Record streak history
+    | -------------------------------------------------------------------------
+    |
+    | Set the streak history configuration.
+    |
+    */
+    'archive_streak_history' => [
+        'enabled' => env(key: 'ARCHIVE_STREAK_HISTORY_ENABLED', default: true),
+    ],
 ];

--- a/database/factories/ActivityFactory.php
+++ b/database/factories/ActivityFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace LevelUp\Experience\Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use LevelUp\Experience\Models\Activity;
+
+class ActivityFactory extends Factory
+{
+    protected $model = Activity::class;
+
+    public function definition(): array
+    {
+        return [
+            'name' => fake()->word,
+            'description' => fake()->sentence,
+        ];
+    }
+}

--- a/database/factories/StreakFactory.php
+++ b/database/factories/StreakFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace LevelUp\Experience\Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use LevelUp\Experience\Models\Activity;
+use LevelUp\Experience\Models\Streak;
+use LevelUp\Experience\Tests\Fixtures\User;
+
+class StreakFactory extends Factory
+{
+    protected $model = Streak::class;
+
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+            'activity_id' => Activity::factory(),
+            'count' => 1,
+            'activity_at' => now(),
+        ];
+    }
+}

--- a/database/migrations/create_streak_activities_table.php.stub
+++ b/database/migrations/create_streak_activities_table.php.stub
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('streak_activities', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->unique();
+            $table->text('description')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('streak_activities');
+    }
+};

--- a/database/migrations/create_streak_histories_table.php.stub
+++ b/database/migrations/create_streak_histories_table.php.stub
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use LevelUp\Experience\Models\Activity;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create(table: 'streak_histories', callback: function (Blueprint $table) {
+            $table->id();
+            $table->foreignId(column: config(key: 'level-up.user.foreign_key'))->constrained(table: config(key: 'level-up.user.users_table'))->cascadeOnDelete();
+            $table->foreignIdFor(model: Activity::class)->constrained(table: 'streak_activities');
+            $table->integer(column: 'count')->default(value: 1);
+            $table->timestamp(column: 'started_at');
+            $table->timestamp(column: 'ended_at');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('streak_histories');
+    }
+};

--- a/database/migrations/create_streaks_table.php.stub
+++ b/database/migrations/create_streaks_table.php.stub
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('streaks', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId(column: 'user_id')->constrained()->onDelete('cascade');
+            $table->foreignId(column: 'activity_id')->constrained()->onDelete('cascade');
+            $table->integer(column: 'count')->default(1);
+            $table->timestamp(column: 'activity_at');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('streaks');
+    }
+};

--- a/database/migrations/create_streaks_table.php.stub
+++ b/database/migrations/create_streaks_table.php.stub
@@ -10,7 +10,7 @@ return new class extends Migration {
         Schema::create('streaks', function (Blueprint $table) {
             $table->id();
             $table->foreignId(column: 'user_id')->constrained()->onDelete('cascade');
-            $table->foreignId(column: 'activity_id')->constrained()->onDelete('cascade');
+            $table->foreignId(column: 'activity_id')->constrained('streak_activities')->onDelete('cascade');
             $table->integer(column: 'count')->default(1);
             $table->timestamp(column: 'activity_at');
             $table->timestamps();

--- a/src/Concerns/HasStreaks.php
+++ b/src/Concerns/HasStreaks.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace LevelUp\Experience\Concerns;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use LevelUp\Experience\Events\StreakIncreased;
+use LevelUp\Experience\Events\StreakStarted;
+use LevelUp\Experience\Models\Activity;
+use LevelUp\Experience\Models\Streak;
+
+trait HasStreaks
+{
+    public function recordStreak(Activity $activity): void
+    {
+        // If the user doesn't have a streak for this activity, start a new one
+        if (! $this->hasStreakForActivity(activity: $activity)) {
+            $this->startNewStreak($activity);
+        }
+
+        $diffInDays = $this->getStreakLastActivity($activity)
+            ->activity_at
+            ->startOfDay()
+            ->diffInDays(now()->startOfDay());
+
+        if ($diffInDays === 0) {
+            return;
+        }
+
+        if ($diffInDays === 1) {
+            $streak = $this->streaks()->whereBelongsTo(related: $activity);
+            $streak->increment(column: 'count');
+            $streak->update(values: ['activity_at' => now()]);
+
+            event(new StreakIncreased($this, $activity, $streak->first()));
+        } else {
+            $this->startNewStreak($activity);
+        }
+    }
+
+    protected function hasStreakForActivity(Activity $activity): bool
+    {
+        return $this->streaks()
+            ->whereBelongsTo(related: $activity)
+            ->exists();
+    }
+
+    public function streaks(): HasMany
+    {
+        return $this->hasMany(related: Streak::class);
+    }
+
+    protected function startNewStreak(Activity $activity): Model|Streak
+    {
+        $streak = $activity->streaks()
+            ->updateOrCreate([
+                'user_id' => $this->id,
+                'activity_id' => $activity->id,
+                'activity_at' => now(),
+            ]);
+
+        event(new StreakStarted($this, $activity, $streak));
+
+        return $streak;
+    }
+
+    protected function getStreakLastActivity(Activity $activity): Streak
+    {
+        return $this->streaks()
+            ->whereBelongsTo(related: $activity)
+            ->latest(column: 'activity_at')
+            ->first();
+    }
+
+    public function getCurrentStreakCount(Activity $activity): int
+    {
+        return $this->streaks()->whereBelongsTo(related: $activity)->first()
+            ? $this->streaks()->whereBelongsTo(related: $activity)->first()->count
+            : 0;
+    }
+
+    public function hasStreakToday(Activity $activity): bool
+    {
+        return $this->getStreakLastActivity($activity)
+            ->activity_at
+            ->isToday();
+    }
+
+    public function resetStreak(Activity $activity): void
+    {
+        $this->streaks()
+            ->whereBelongsTo(related: $activity)
+            ->update(['count' => 1]);
+    }
+
+    //    public function getLongestStreak(Activity $activity): int
+    //    {
+    //        return $this->streaks()
+    //            ->whereBelongsTo(related: $activity)
+    //            ->max(column: 'count');
+    //    }
+}

--- a/src/Concerns/HasStreaks.php
+++ b/src/Concerns/HasStreaks.php
@@ -86,7 +86,9 @@ trait HasStreaks
     public function resetStreak(Activity $activity): void
     {
         // Archive the streak
-        $this->archiveStreak($activity);
+        if (config(key: 'level-up.archive_streak_history.enabled')) {
+            $this->archiveStreak($activity);
+        }
 
         $this->streaks()
             ->whereBelongsTo(related: $activity)

--- a/src/Events/StreakBroken.php
+++ b/src/Events/StreakBroken.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace LevelUp\Experience\Events;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Events\Dispatchable;
+use LevelUp\Experience\Models\Activity;
+use LevelUp\Experience\Models\Streak;
+
+class StreakBroken
+{
+    use Dispatchable;
+
+    public function __construct(
+        public Model $user,
+        public Activity $activity,
+        public Streak $streak,
+    ) {
+    }
+}

--- a/src/Events/StreakIncreased.php
+++ b/src/Events/StreakIncreased.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace LevelUp\Experience\Events;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Events\Dispatchable;
+use LevelUp\Experience\Models\Activity;
+use LevelUp\Experience\Models\Streak;
+
+class StreakIncreased
+{
+    use Dispatchable;
+
+    public function __construct(
+        public Model $user,
+        public Activity $activity,
+        public Streak $streak,
+    ) {
+    }
+}

--- a/src/Events/StreakStarted.php
+++ b/src/Events/StreakStarted.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace LevelUp\Experience\Events;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Events\Dispatchable;
+use LevelUp\Experience\Models\Activity;
+use LevelUp\Experience\Models\Streak;
+
+class StreakStarted
+{
+    use Dispatchable;
+
+    public function __construct(
+        public Model $user,
+        public Activity $activity,
+        public Streak $streak,
+    ) {
+    }
+}

--- a/src/LevelUpServiceProvider.php
+++ b/src/LevelUpServiceProvider.php
@@ -24,8 +24,9 @@ class LevelUpServiceProvider extends PackageServiceProvider
                 'create_experience_audits_table',
                 'create_achievements_table',
                 'create_achievement_user_pivot_table',
-                'create_streaks_table',
                 'create_streak_activities_table',
+                'create_streaks_table',
+                'create_streak_histories_table',
             ]);
     }
 

--- a/src/LevelUpServiceProvider.php
+++ b/src/LevelUpServiceProvider.php
@@ -24,6 +24,8 @@ class LevelUpServiceProvider extends PackageServiceProvider
                 'create_experience_audits_table',
                 'create_achievements_table',
                 'create_achievement_user_pivot_table',
+                'create_streaks_table',
+                'create_streak_activities_table',
             ]);
     }
 

--- a/src/Models/Activity.php
+++ b/src/Models/Activity.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace LevelUp\Experience\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Activity extends Model
+{
+    use HasFactory;
+
+    protected $table = 'streak_activities';
+
+    protected $guarded = [];
+
+    public function streaks(): HasMany
+    {
+        return $this->hasMany(related: Streak::class);
+    }
+}

--- a/src/Models/Pivots/AchievementUser.php
+++ b/src/Models/Pivots/AchievementUser.php
@@ -2,12 +2,14 @@
 
 namespace LevelUp\Experience\Models\Pivots;
 
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Relations\Pivot;
 
 class AchievementUser extends Pivot
 {
-    public function scopeWithProgress($query, int $progress)
+    public function scopeWithProgress(Builder $query, int $progress): Collection
     {
-        return $query->where('progress', $progress)->get();
+        return $query->where(column: 'progress', operator: $progress)->get();
     }
 }

--- a/src/Models/Streak.php
+++ b/src/Models/Streak.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace LevelUp\Experience\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Streak extends Model
+{
+    use HasFactory;
+
+    protected $guarded = [];
+
+    protected $casts = [
+        'activity_at' => 'datetime',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(config(key: 'level-up.user.model'));
+    }
+
+    public function activity(): BelongsTo
+    {
+        return $this->belongsTo(related: Activity::class);
+    }
+}

--- a/src/Models/StreakHistory.php
+++ b/src/Models/StreakHistory.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace LevelUp\Experience\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class StreakHistory extends Model
+{
+    protected $guarded = [];
+
+    protected $casts = [
+        'started_at' => 'datetime',
+        'ended_at' => 'datetime',
+    ];
+}

--- a/src/Providers/MultiplierServiceProvider.php
+++ b/src/Providers/MultiplierServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace LevelUp\Experience\Providers;
 
+use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\ServiceProvider;
 use LevelUp\Experience\Services\MultiplierService;
@@ -13,10 +14,10 @@ class MultiplierServiceProvider extends ServiceProvider
     {
         $this->app->bind(
             abstract: MultiplierService::class,
-            concrete: fn ($app, array $params): MultiplierService => new MultiplierService(
+            concrete: fn (Application $app, array $params): MultiplierService => new MultiplierService(
                 multipliers: collect(value: File::allFiles(config(key: 'level-up.multiplier.path')))
-                    ->map(callback: fn ($file): ReflectionClass => new ReflectionClass(sprintf('%s%s', config(key: 'level-up.multiplier.namespace'), str($file->getFilename())->replace(search: '.php', replace: ''))))
-                    ->filter(callback: fn (ReflectionClass $class): bool => $class->getProperty('enabled')->getValue($class->newInstance()) === true)
+                    ->map(callback: fn ($file) => new ReflectionClass(sprintf('%s%s', config(key: 'level-up.multiplier.namespace'), str($file->getFilename())->replace(search: '.php', replace: ''))))
+                    ->filter(callback: fn (ReflectionClass $class): bool => $class->getProperty(name: 'enabled')->getValue($class->newInstance()) === true)
                     ->map(callback: fn (ReflectionClass $class) => $app->make($class->getName())),
                 data: $params['data'] ?? []
             )

--- a/src/Services/LeaderboardService.php
+++ b/src/Services/LeaderboardService.php
@@ -3,6 +3,7 @@
 namespace LevelUp\Experience\Services;
 
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use LevelUp\Experience\Models\Experience;
 
@@ -15,7 +16,7 @@ class LeaderboardService
         $this->userModel = config(key: 'level-up.user.model');
     }
 
-    public function generate($paginate = false, int|null $limit = null): array|Collection|LengthAwarePaginator
+    public function generate(bool $paginate = false, int $limit = null): array|Collection|LengthAwarePaginator
     {
         return $this->userModel::query()
             ->with(relations: ['experience', 'level'])
@@ -25,6 +26,6 @@ class LeaderboardService
                     ->latest()
             )
             ->take($limit)
-            ->when($paginate, fn ($query) => $query->paginate(), fn ($query) => $query->get());
+            ->when($paginate, fn (Builder $query) => $query->paginate(), fn (Builder $query) => $query->get());
     }
 }

--- a/src/Services/MultiplierService.php
+++ b/src/Services/MultiplierService.php
@@ -7,8 +7,8 @@ use Illuminate\Support\Collection;
 class MultiplierService
 {
     public function __construct(
-        private Collection $multipliers,
-        private array $data = [],
+        private readonly Collection $multipliers,
+        private readonly array $data = [],
     ) {
     }
 
@@ -16,7 +16,7 @@ class MultiplierService
     {
         /** @var \LevelUp\Experience\Contracts\Multiplier $multiplier */
         return $this->multipliers->reduce(
-            callback: fn ($amount, $multiplier) => $multiplier->qualifies($this->getMultiplierData()->toArray())
+            callback: fn (int $amount, $multiplier) => $multiplier->qualifies($this->getMultiplierData()->toArray())
                 ? $amount * $multiplier->setMultiplier()
                 : $amount,
             initial: $points

--- a/tests/Concerns/HasStreaksTest.php
+++ b/tests/Concerns/HasStreaksTest.php
@@ -139,13 +139,7 @@ test(description: 'a User\'s streak can be reset', closure: function () {
 
     expect($this->user->hasStreakToday($this->activity))->toBeTrue();
 
-    // Mimic recording a streak the next day
-    // Setting Carbon::setTestNow() doesn't seem to work
-    $this->activity->streaks->first()->update([
-        'count' => 2,
-        'activity_at' => now()->addDay(),
-    ]);
-
+    testTime()->addDay();
     $this->user->resetStreak($this->activity);
 
     expect($this->user->getCurrentStreakCount($this->activity))->toBe(expected: 1);

--- a/tests/Concerns/HasStreaksTest.php
+++ b/tests/Concerns/HasStreaksTest.php
@@ -1,0 +1,129 @@
+<?php
+
+use Illuminate\Support\Facades\Event;
+use LevelUp\Experience\Events\StreakIncreased;
+use LevelUp\Experience\Events\StreakStarted;
+use LevelUp\Experience\Models\Activity;
+
+uses()->group('streaks');
+
+test(description: 'record a streak if one does not exist for the activity', closure: function () {
+    Event::fake();
+
+    $this->activity = Activity::factory()->createOne();
+
+    $this->user->recordStreak($this->activity);
+
+    Event::assertDispatched(event: StreakStarted::class,
+        callback: fn (StreakStarted $event): bool => $event->user->is($this->user)
+            && $event->activity->is($this->activity)
+            && $event->streak->activity_at->isToday(),
+    );
+
+    expect($this->activity->streaks)->toHaveCount(count: 1);
+
+    $this->assertDatabaseHas(table: 'streaks', data: [
+        'user_id' => $this->user->id,
+        'activity_id' => $this->activity->id,
+        'count' => 1,
+        'activity_at' => now(),
+    ]);
+});
+
+test(description: 'if an activity happens more than once on the same day, nothing will happen', closure: function () {
+    // First, create a streak record
+    $this->activity = Activity::factory()->createOne();
+
+    $this->user->recordStreak($this->activity);
+
+    expect($this->activity->streaks)->toHaveCount(count: 1);
+
+    // Now, simulate the same activity being recorded
+    $this->user->recordStreak($this->activity);
+
+    // ... there should still only be one streak record
+    expect($this->activity->streaks)->toHaveCount(count: 1);
+
+    // Finally, check the data hasn't changed
+    $this->assertDatabaseHas(table: 'streaks', data: [
+        'user_id' => $this->user->id,
+        'activity_id' => $this->activity->id,
+        'count' => 1,
+        'activity_at' => now(),
+    ]);
+});
+
+test(description: 'when a streak record exists, update the data', closure: function () {
+    Event::fake();
+
+    // First, create a streak record
+    $this->activity = Activity::factory()->createOne();
+
+    $this->user->recordStreak($this->activity);
+
+    expect($this->activity->streaks)->toHaveCount(count: 1);
+
+    // Now, simulate the record happening the next day and instead, been updated
+    // Using Carbon::setTestNow() doesn't seem to work here
+    // This is the equivalent of recording a streak the next day
+    $this->activity->streaks->first()->update([
+        'activity_at' => now()->addDay(),
+    ]);
+
+    $this->user->recordStreak($this->activity);
+
+    Event::assertDispatched(event: StreakIncreased::class,
+        callback: fn (StreakIncreased $event): bool => $event->user->is($this->user)
+            && $event->activity->is($this->activity)
+            && $event->streak->activity_at->isToday()
+            && $event->streak->count === 2
+    );
+
+    // There should still only be one streak record
+    expect($this->activity->streaks)->toHaveCount(count: 1);
+
+    // Finally, check the data has been updated
+    $this->assertDatabaseHas(table: 'streaks', data: [
+        'user_id' => $this->user->id,
+        'activity_id' => $this->activity->id,
+        'count' => 2,
+        'activity_at' => now(),
+    ]);
+});
+
+test(description: 'the Users current streak count is correct', closure: function () {
+    $this->activity = Activity::factory()->createOne();
+
+    $this->user->recordStreak($this->activity);
+
+    expect($this->user->streaks)->toHaveCount(count: 1)
+        ->and($this->user->getCurrentStreakCount($this->activity))->toBe(1);
+});
+
+test(description: 'a User has a streak going', closure: function () {
+    $this->activity = Activity::factory()->createOne();
+
+    $this->user->recordStreak($this->activity);
+
+    expect($this->user->hasStreakToday($this->activity))->toBeTrue();
+});
+
+// test the streak can be reset
+test(description: 'a User\'s streak can be reset', closure: function () {
+    $this->activity = Activity::factory()->createOne();
+
+    $this->user->recordStreak($this->activity);
+
+    expect($this->user->hasStreakToday($this->activity))->toBeTrue();
+
+    // Mimic recording a streak the next day
+    // Setting Carbon::setTestNow() doesn't seem to work
+    $this->activity->streaks->first()->update([
+        'count' => 2,
+        'activity_at' => now()->addDay(),
+    ]);
+
+    $this->user->resetStreak($this->activity);
+
+    expect($this->user->getCurrentStreakCount($this->activity))->toBe(expected: 1);
+});

--- a/tests/Concerns/HasStreaksTest.php
+++ b/tests/Concerns/HasStreaksTest.php
@@ -6,7 +6,7 @@ use LevelUp\Experience\Events\StreakIncreased;
 use LevelUp\Experience\Events\StreakStarted;
 use LevelUp\Experience\Models\Activity;
 
-use function Spatie\PestPluginTestTime\testTime;
+use function Pest\Laravel\travel;
 
 uses()->group('streaks');
 
@@ -64,7 +64,7 @@ test(description: 'when a streak record exists, update the data', closure: funct
         ->and($this->activity->streaks->first()->activity_at->isToday());
 
     // Now, simulate the record happening the next day and instead, been updated
-    testTime()->addDay();
+    travel(1)->day();
 
     $this->user->recordStreak($this->activity);
 
@@ -97,7 +97,7 @@ test(description: 'a User\'s streak is broken when they miss a day', closure: fu
         ->and($this->activity->streaks->first()->activity_at->isToday());
 
     // Simulate the activity happening again the next day
-    testTime()->addDays();
+    travel(1)->day();
 
     $this->user->recordStreak($this->activity);
     expect(value: $this->activity->streaks)->toHaveCount(count: 1)
@@ -105,12 +105,12 @@ test(description: 'a User\'s streak is broken when they miss a day', closure: fu
         ->and($this->activity->streaks->first()->activity_at->isTomorrow());
 
     // Simulate the activity happening again the next day
-    testTime()->addDays(2);
+    travel(2)->days();
 
     $this->user->recordStreak($this->activity);
     expect(value: $this->activity->streaks)->toHaveCount(count: 1)
         ->and($this->activity->fresh()->streaks->first()->count)->toBe(expected: 1)
-        ->and($this->activity->fresh()->streaks->first()->activity_at)->toBeCarbon(now());
+        ->and($this->activity->fresh()->streaks->first()->activity_at)->isToday();
 
     Event::assertDispatched(
         event: StreakBroken::class,
@@ -139,7 +139,7 @@ test(description: 'a User\'s streak can be reset', closure: function () {
 
     expect($this->user->hasStreakToday($this->activity))->toBeTrue();
 
-    testTime()->addDay();
+    travel(1)->day();
     $this->user->resetStreak($this->activity);
 
     expect($this->user->getCurrentStreakCount($this->activity))->toBe(expected: 1);
@@ -151,18 +151,18 @@ test(description: 'when a streak is broken, it is also archived for historical u
     $this->user->recordStreak($this->activity);
 
     // Day 2
-    testTime()->addDays();
+    travel(1)->day();
     $this->user->recordStreak($this->activity);
 
     // Day 3
-    testTime()->addDays();
+    travel(1)->day();
     $this->user->recordStreak($this->activity);
 
     expect($this->user->streaks)->toHaveCount(count: 1)
         ->and($this->user->getCurrentStreakCount($this->activity))->toBe(3);
 
     // Now, break the streak
-    testTime()->addDays(2);
+    travel(2)->days();
     $this->user->recordStreak($this->activity);
 
     expect($this->user->getCurrentStreakCount($this->activity))->toBe(expected: 1);

--- a/tests/Fixtures/User.php
+++ b/tests/Fixtures/User.php
@@ -3,15 +3,19 @@
 namespace LevelUp\Experience\Tests\Fixtures;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use LevelUp\Experience\Concerns\GiveExperience;
 use LevelUp\Experience\Concerns\HasAchievements;
+use LevelUp\Experience\Concerns\HasStreaks;
 use LevelUp\Experience\Tests\Fixtures\Factories\UserFactory;
 
 class User extends Model
 {
     use GiveExperience;
     use HasAchievements;
+    use HasFactory;
+    use HasStreaks;
 
     protected $guarded = [];
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,12 +2,11 @@
 
 namespace LevelUp\Experience\Tests;
 
-use AllowDynamicProperties;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use LevelUp\Experience\LevelUpServiceProvider;
 use Orchestra\Testbench\TestCase as Orchestra;
 
-#[AllowDynamicProperties] class TestCase extends Orchestra
+class TestCase extends Orchestra
 {
     protected function setUp(): void
     {
@@ -55,6 +54,12 @@ use Orchestra\Testbench\TestCase as Orchestra;
         $migration->up();
 
         $migration = include __DIR__.'/../database/migrations/create_achievement_user_pivot_table.php.stub';
+        $migration->up();
+
+        $migration = include __DIR__.'/../database/migrations/create_streaks_table.php.stub';
+        $migration->up();
+
+        $migration = include __DIR__.'/../database/migrations/create_streak_activities_table.php.stub';
         $migration->up();
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -56,10 +56,13 @@ class TestCase extends Orchestra
         $migration = include __DIR__.'/../database/migrations/create_achievement_user_pivot_table.php.stub';
         $migration->up();
 
+        $migration = include __DIR__.'/../database/migrations/create_streak_activities_table.php.stub';
+        $migration->up();
+
         $migration = include __DIR__.'/../database/migrations/create_streaks_table.php.stub';
         $migration->up();
 
-        $migration = include __DIR__.'/../database/migrations/create_streak_activities_table.php.stub';
+        $migration = include __DIR__.'/../database/migrations/create_streak_histories_table.php.stub';
         $migration->up();
     }
 }


### PR DESCRIPTION
This PR introduces a new feature: **Streaks**

This allows an activity to be created, like logging into a website, or posting an article, and on each successful day where the activity is recorded, a streak runs. 

Streaks are broken when you miss a day. A streak will be reset and you will start again.

Streaks are also recorded for historical purposes (thought this can be turned off)

See the README which documents how to use this feature.