### PR TITLE
Adds a feature to freeze a streak

### DIFF
--- a/.github/workflows/run-linter.yml
+++ b/.github/workflows/run-linter.yml
@@ -1,0 +1,21 @@
+name: "Run Linter"
+
+on: pull_request
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Lint with Pint
+        uses: aglipanci/laravel-pint-action@2.3.0
+
+      - name: Commit linted files
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: "fix: Files linted with Pint"
+

--- a/README.md
+++ b/README.md
@@ -591,6 +591,59 @@ public Activity $activity,
 public Streak $streak,
 ```
 
+## 🥶 Streak Freezing
+
+Streaks can be frozen, which means they will not be broken if a day is skipped. This is useful for when you want to allow users to take a break from an activity without losing their streak.
+
+The freeze duration is a configurable option in the config file.
+
+```php
+'freeze_duration' => env(key: 'STREAK_FREEZE_DURATION', default: 1),
+```
+
+### Freeze a Streak
+
+Fetch the activity you want to freeze and pass it to the `freezeStreak` method. A second parameter can be passed to set the duration of the freeze. The default is `1` day (as set in the config)
+
+A `StreakFrozen` Event is ran when a streak is frozen.
+
+```php
+$user->freezeStreak(activity: $activity);
+
+$user->freezeStreak(activity: $activity, days: 5); // freeze for 5 days
+```
+
+### Unfreeze a Streak
+
+The opposite of freezing a streak is unfreezing it. This will allow the streak to be broken again.
+
+A `StreakUnfrozen` Event is run when a streak is unfrozen.
+
+```php
+$user->unfreezeStreak($activity);
+```
+
+### Check if a Streak is Frozen
+
+```php
+$user->isStreakFrozen($activity);
+```
+
+### Events
+
+**StreakFrozen** - When a streak is frozen.
+
+```php
+public int $frozenStreakLength,
+public Carbon $frozenUntil,
+```
+
+**StreakUnfrozen** - When a streak is unfrozen.
+
+```
+No data is sent with this event
+```
+
 # Testing
 
 ```

--- a/config/level-up.php
+++ b/config/level-up.php
@@ -86,4 +86,14 @@ return [
     'archive_streak_history' => [
         'enabled' => env(key: 'ARCHIVE_STREAK_HISTORY_ENABLED', default: true),
     ],
+
+    /*
+     | -------------------------------------------------------------------------
+     | Default Streak Freeze Time
+     | -------------------------------------------------------------------------
+     |
+     | Set the default time in days that a streak will be frozen for.
+     |
+     */
+    'freeze_duration' => env(key: 'STREAK_FREEZE_DURATION', default: 1),
 ];

--- a/database/migrations/add_streak_freeze_feature_columns_to_streaks_table.php.stub
+++ b/database/migrations/add_streak_freeze_feature_columns_to_streaks_table.php.stub
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('streaks', function (Blueprint $table) {
+            $table->after('activity_at', function (Blueprint $table) {
+                $table->timestamp('frozen_until')->nullable();
+            });
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('streaks', function (Blueprint $table) {
+            $table->dropColumn('frozen_until');
+        });
+    }
+};

--- a/src/Concerns/HasStreaks.php
+++ b/src/Concerns/HasStreaks.php
@@ -4,9 +4,12 @@ namespace LevelUp\Experience\Concerns;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Facades\Event;
 use LevelUp\Experience\Events\StreakBroken;
+use LevelUp\Experience\Events\StreakFrozen;
 use LevelUp\Experience\Events\StreakIncreased;
 use LevelUp\Experience\Events\StreakStarted;
+use LevelUp\Experience\Events\StreakUnfroze;
 use LevelUp\Experience\Models\Activity;
 use LevelUp\Experience\Models\Streak;
 use LevelUp\Experience\Models\StreakHistory;
@@ -136,12 +139,19 @@ trait HasStreaks
     {
         $days = $days ?? config(key: 'level-up.freeze_duration');
 
+        Event::dispatch(new StreakFrozen(
+            frozenStreakLength: $days,
+            frozenUntil: now()->addDays(value: $days)->startOfDay()
+        ));
+
         return $this->getStreakLastActivity($activity)
             ->update(['frozen_until' => now()->addDays(value: $days)->startOfDay()]);
     }
 
     public function unFreezeStreak(Activity $activity): bool
     {
+        Event::dispatch(new StreakUnfroze());
+
         return $this->getStreakLastActivity($activity)
             ->update(['frozen_until' => null]);
     }

--- a/src/Events/StreakFrozen.php
+++ b/src/Events/StreakFrozen.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace LevelUp\Experience\Events;
+
+use Illuminate\Support\Carbon;
+
+class StreakFrozen
+{
+    public function __construct(
+        public int $frozenStreakLength,
+        public Carbon $frozenUntil,
+    ) {
+    }
+}

--- a/src/Events/StreakUnfroze.php
+++ b/src/Events/StreakUnfroze.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace LevelUp\Experience\Events;
+
+class StreakUnfroze
+{
+    public function __construct()
+    {
+    }
+}

--- a/src/LevelUpServiceProvider.php
+++ b/src/LevelUpServiceProvider.php
@@ -27,6 +27,7 @@ class LevelUpServiceProvider extends PackageServiceProvider
                 'create_streak_activities_table',
                 'create_streaks_table',
                 'create_streak_histories_table',
+                'add_streak_freeze_feature_columns_to_streaks_table',
             ]);
     }
 

--- a/src/Models/Streak.php
+++ b/src/Models/Streak.php
@@ -14,6 +14,7 @@ class Streak extends Model
 
     protected $casts = [
         'activity_at' => 'datetime',
+        'frozen_until' => 'datetime',
     ];
 
     public function user(): BelongsTo

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -38,31 +38,23 @@ class TestCase extends Orchestra
             $table->timestamps();
         });
 
-        $migration = include __DIR__.'/../database/migrations/create_levels_table.php.stub';
-        $migration->up();
+        $migrationFiles = [
+            'create_levels_table',
+            'create_experiences_table',
+            'add_level_relationship_to_users_table',
+            'create_experience_audits_table',
+            'create_achievements_table',
+            'create_achievement_user_pivot_table',
+            'create_streak_activities_table',
+            'create_streaks_table',
+            'create_streak_histories_table',
+            'add_streak_freeze_feature_columns_to_streaks_table',
+        ];
 
-        $migration = include __DIR__.'/../database/migrations/create_experiences_table.php.stub';
-        $migration->up();
+        foreach ($migrationFiles as $migrationFile) {
+            $migration = include __DIR__."/../database/migrations/$migrationFile.php.stub";
 
-        $migration = include __DIR__.'/../database/migrations/add_level_relationship_to_users_table.php.stub';
-        $migration->up();
-
-        $migration = include __DIR__.'/../database/migrations/create_experience_audits_table.php.stub';
-        $migration->up();
-
-        $migration = include __DIR__.'/../database/migrations/create_achievements_table.php.stub';
-        $migration->up();
-
-        $migration = include __DIR__.'/../database/migrations/create_achievement_user_pivot_table.php.stub';
-        $migration->up();
-
-        $migration = include __DIR__.'/../database/migrations/create_streak_activities_table.php.stub';
-        $migration->up();
-
-        $migration = include __DIR__.'/../database/migrations/create_streaks_table.php.stub';
-        $migration->up();
-
-        $migration = include __DIR__.'/../database/migrations/create_streak_histories_table.php.stub';
-        $migration->up();
+            $migration->up();
+        }
     }
 }


### PR DESCRIPTION
This PR adds a sub-feature of the Streak feature which allows you to freeze a streak for a set period of time meaning the User will not lose their streak.

I have also added a new GitHub Action workflow to run a Linter.