### PR TITLE
Add custom expectation for Carbon instances and level cap validation

### DIFF
--- a/src/Concerns/GiveExperience.php
+++ b/src/Concerns/GiveExperience.php
@@ -30,6 +30,12 @@ trait GiveExperience
             $type = AuditType::Add->value;
         }
 
+        $lastLevel = Level::orderByDesc(column: 'level')->first();
+        throw_if(
+            condition: isset($lastLevel->next_level_experience) && $amount > Level::orderByDesc(column: 'level')->first()->next_level_experience,
+            message: 'Points exceed the last level\'s experience points.',
+        );
+
         /**
          * If the Multiplier Service is enabled, apply the Multipliers.
          */
@@ -180,7 +186,7 @@ trait GiveExperience
         }
 
         $this->update(attributes: [
-            'level_id' => $nextLevel->id,
+            'level_id' => $nextLevel->level,
         ]);
 
         event(new UserLevelledUp(user: $this, level: $this->getLevel()));

--- a/tests/Concerns/GiveExperienceTest.php
+++ b/tests/Concerns/GiveExperienceTest.php
@@ -299,3 +299,8 @@ test(description: 'Add default level if not applied before trying to add points'
         'next_level_experience' => null,
     ]);
 });
+
+it('throws an error when points added exceed the last levels experience requirement')
+    ->defer(fn () => $this->user->addPoints(amount: 1000))
+    ->throws(exception: \Exception::class);
+

--- a/tests/Concerns/GiveExperienceTest.php
+++ b/tests/Concerns/GiveExperienceTest.php
@@ -303,4 +303,3 @@ test(description: 'Add default level if not applied before trying to add points'
 it('throws an error when points added exceed the last levels experience requirement')
     ->defer(fn () => $this->user->addPoints(amount: 1000))
     ->throws(exception: \Exception::class);
-

--- a/tests/Concerns/HasStreaksTest.php
+++ b/tests/Concerns/HasStreaksTest.php
@@ -63,7 +63,7 @@ test(description: 'when a streak record exists, update the data', closure: funct
 
     expect($this->activity)->streaks->toHaveCount(count: 1)
         ->and($this->activity)->streaks->first()->count->toBe(expected: 1)
-        ->and($this->activity)->streaks->first()->activity_at->format('U')->toBe(now()->format('U'));
+        ->and($this->activity)->streaks->first()->activity_at->toBeCarbon(now());
 
     // Now, simulate the record happening the next day and instead, been updated
     travel(1)->day();
@@ -96,7 +96,7 @@ test(description: 'a User\'s streak is broken when they miss a day', closure: fu
     $this->user->recordStreak($this->activity);
     expect(value: $this->activity)->streaks->toHaveCount(count: 1)
         ->and($this->activity)->streaks->first()->count->toBe(expected: 1)
-        ->and($this->activity)->streaks->first()->activity_at->format('U')->toBe(now()->format('U'));
+        ->and($this->activity)->streaks->first()->activity_at->toBeCarbon(now());
 
     // Simulate the activity happening again the next day
     travel(value: 1)->day();
@@ -104,7 +104,7 @@ test(description: 'a User\'s streak is broken when they miss a day', closure: fu
     $this->user->recordStreak($this->activity);
     expect(value: $this->activity)->streaks->toHaveCount(count: 1)
         ->and($this->activity)->fresh()->streaks->first()->count->toBe(expected: 2)
-        ->and($this->activity)->fresh()->streaks->first()->activity_at->format('U')->toBe(now()->format('U'));
+        ->and($this->activity)->fresh()->streaks->first()->activity_at->toBeCarbon(now());
 
     // Simulate the activity happening again the next day
     travel(value: 2)->days();
@@ -112,7 +112,7 @@ test(description: 'a User\'s streak is broken when they miss a day', closure: fu
     $this->user->recordStreak($this->activity);
     expect(value: $this->activity->streaks)->toHaveCount(count: 1)
         ->and($this->activity)->fresh()->streaks->first()->count->toBe(expected: 1)
-        ->and($this->activity)->fresh()->streaks->first()->activity_at->format('U')->toBe(now()->format('U'));
+        ->and($this->activity)->fresh()->streaks->first()->activity_at->toBeCarbon(now());
 
     Event::assertDispatched(
         event: StreakBroken::class,
@@ -186,7 +186,7 @@ test(description: 'a streak can be frozen', closure: function () {
 
     $this->user->freezeStreak($this->activity);
 
-    expect($this->user)->streaks->first()->frozen_until->format('U')->toBe(now()->addDays()->startOfDay()->format('U'));
+    expect($this->user)->streaks->first()->frozen_until->toBeCarbon(now()->addDays()->startOfDay());
 
     Event::assertDispatched(
         event: StreakFrozen::class,
@@ -202,7 +202,7 @@ test(description: 'a streak can be unfrozen', closure: function () {
 
     $this->user->freezeStreak($this->activity);
 
-    expect($this->user)->streaks->first()->frozen_until->format('U')->toBe(now()->addDays()->startOfDay()->format('U'));
+    expect($this->user)->streaks->first()->frozen_until->toBeCarbon(now()->addDays()->startOfDay());
 
     $this->user->unFreezeStreak($this->activity);
 

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -26,3 +26,17 @@ uses(TestCase::class, FastRefreshDatabase::class)
         );
     })
     ->in(__DIR__);
+
+// A custom expectation to check if a Carbon instance matches a given string
+// Stolen from https://github.com/spatie/pest-plugin-test-time
+expect()->extend(name: 'toBeCarbon', extend: function (string $expected, string $format = null) {
+    if ($format === null) {
+        $format = str_contains($expected, ':')
+            ? 'Y-m-d H:i:s'
+            : 'Y-m-d';
+    }
+
+    expect($this->value?->format($format))->toBe($expected);
+
+    return $this;
+});


### PR DESCRIPTION
A custom expectation for Carbon instances named 'toBeCarbon' was added in the 'tests/Pest.php' file to improve date format tests. It was inspired by the similar expectation in the Pest Plugin Test Time.

In the 'src/Concerns/GiveExperience.php' file, a check was included to ensure that the points awarded do not exceed the experience requirement for the last level. This validation helps keep the game balanced and prevents unreasonable levels of experience. The respective test was added in the 'tests/Concerns/GiveExperienceTest.php' file.

In the 'tests/Concerns/HasStreaksTest.php' file, all the date comparisons were updated to use the new 'toBeCarbon' expectation. This makes these tests cleaner and easier to understand.

Closes #36 