### PR TITLE
Add level calculation and event dispatch on initial experience gain

### DIFF
--- a/src/Concerns/GiveExperience.php
+++ b/src/Concerns/GiveExperience.php
@@ -69,7 +69,6 @@ trait GiveExperience
                 'level_id' => $experience->level_id,
             ])->save();
 
-
             if ($level?->level > config(key: 'level-up.starting_level')) {
                 Event::dispatch(event: new UserLevelledUp(user: $this, level: $level->level));
             }

--- a/src/Listeners/UserLevelledUpListener.php
+++ b/src/Listeners/UserLevelledUpListener.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace LevelUp\Experience\Listeners;
+
+use LevelUp\Experience\Enums\AuditType;
+use LevelUp\Experience\Events\UserLevelledUp;
+
+class UserLevelledUpListener
+{
+    public function __invoke(UserLevelledUp $event): void
+    {
+        if (config(key: 'level-up.audit.enabled')) {
+            $event->user->experienceHistory()->create(attributes: [
+                'user_id' => $event->user->id,
+                'points' => $event->user->getPoints(),
+                'levelled_up' => true,
+                'level_to' => $event->level,
+                'type' => AuditType::LevelUp->value,
+            ]);
+        }
+    }
+}

--- a/src/Providers/EventServiceProvider.php
+++ b/src/Providers/EventServiceProvider.php
@@ -4,13 +4,18 @@ namespace LevelUp\Experience\Providers;
 
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
 use LevelUp\Experience\Events\PointsIncreased;
+use LevelUp\Experience\Events\UserLevelledUp;
 use LevelUp\Experience\Listeners\PointsIncreasedListener;
+use LevelUp\Experience\Listeners\UserLevelledUpListener;
 
 class EventServiceProvider extends ServiceProvider
 {
     protected $listen = [
         PointsIncreased::class => [
             PointsIncreasedListener::class,
+        ],
+        UserLevelledUp::class => [
+            UserLevelledUpListener::class,
         ],
     ];
 

--- a/tests/Concerns/GiveExperienceTest.php
+++ b/tests/Concerns/GiveExperienceTest.php
@@ -150,8 +150,10 @@ test('a User can see how many more points are needed until they can level up', c
 it(description: 'returns zero when User has hit Level cap and tries to see how many points until next level', closure: function () {
     config()->set(key: 'level-up.level_cap.enabled', value: true);
     config()->set(key: 'level-up.level_cap.level', value: 3);
+    config()->set(key: 'level-up.level_cap.points_continue', value: false);
 
-    $this->user->addPoints(amount: 250);
+    $this->user->addPoints(amount: 100);
+    $this->user->addPoints(amount: 150);
 
     expect($this->user)
         ->nextLevelAt()

--- a/tests/Concerns/GiveExperienceTest.php
+++ b/tests/Concerns/GiveExperienceTest.php
@@ -5,7 +5,6 @@ use Illuminate\Support\Facades\Event;
 use LevelUp\Experience\Events\PointsDecreased;
 use LevelUp\Experience\Events\PointsIncreased;
 use LevelUp\Experience\Events\UserLevelledUp;
-use LevelUp\Experience\Listeners\PointsIncreasedListener;
 use LevelUp\Experience\Models\Experience;
 use LevelUp\Experience\Models\Level;
 
@@ -333,13 +332,4 @@ it(description: 'dispatches an event after points have been added for the very f
     $this->user->addPoints(amount: 250);
 
     Event::assertDispatched(event: UserLevelledUp::class);
-});
-
-test('events', function () {
-    Event::fake();
-
-    $this->user->addPoints(amount: 10);
-
-    Event::assertDispatched(event: PointsIncreased::class);
-    Event::assertListening(expectedEvent: PointsIncreased::class, expectedListener: PointsIncreasedListener::class);
 });

--- a/tests/Concerns/GiveExperienceTest.php
+++ b/tests/Concerns/GiveExperienceTest.php
@@ -5,6 +5,7 @@ use Illuminate\Support\Facades\Event;
 use LevelUp\Experience\Events\PointsDecreased;
 use LevelUp\Experience\Events\PointsIncreased;
 use LevelUp\Experience\Events\UserLevelledUp;
+use LevelUp\Experience\Listeners\PointsIncreasedListener;
 use LevelUp\Experience\Models\Experience;
 use LevelUp\Experience\Models\Level;
 
@@ -332,4 +333,13 @@ it(description: 'dispatches an event after points have been added for the very f
     $this->user->addPoints(amount: 250);
 
     Event::assertDispatched(event: UserLevelledUp::class);
+});
+
+test('events', function () {
+    Event::fake();
+
+    $this->user->addPoints(amount: 10);
+
+    Event::assertDispatched(event: PointsIncreased::class);
+    Event::assertListening(expectedEvent: PointsIncreased::class, expectedListener: PointsIncreasedListener::class);
 });

--- a/tests/Concerns/GiveExperienceTest.php
+++ b/tests/Concerns/GiveExperienceTest.php
@@ -300,7 +300,34 @@ test(description: 'Add default level if not applied before trying to add points'
     ]);
 });
 
-it('throws an error when points added exceed the last levels experience requirement')
+it(description: 'throws an error when points added exceed the last levels experience requirement')
     ->defer(fn () => $this->user->addPoints(amount: 1000))
     ->throws(exception: \Exception::class);
 
+test(description: 'the level is correct when adding more points than available on initial experience gain', closure: function () {
+    // Levels have been added, up to Level 5, needing to reach 600 points to get there
+    // User is initially given 400 points, so should directly go to Level 4
+    $this->user->addPoints(amount: 10);
+    expect($this->user)->level_id->toBe(expected: 1);
+    $this->user->setPoints(amount: 0);
+
+    $this->user->addPoints(100);
+    expect($this->user)->level_id->toBe(expected: 2);
+    $this->user->setPoints(amount: 0);
+
+    $this->user->addPoints(250);
+    expect($this->user)->level_id->toBe(expected: 3);
+    $this->user->setPoints(amount: 0);
+
+    $this->user->addPoints(400);
+    expect($this->user)->level_id->toBe(expected: 4);
+    $this->user->setPoints(amount: 0);
+});
+
+it(description: 'dispatches an event after points have been added for the very first time', closure: function () {
+    Event::fake();
+
+    $this->user->addPoints(amount: 250);
+
+    Event::assertDispatched(event: UserLevelledUp::class);
+});

--- a/tests/Listeners/UserLevelledUpListenerTest.php
+++ b/tests/Listeners/UserLevelledUpListenerTest.php
@@ -1,0 +1,20 @@
+<?php
+
+beforeEach(closure: function (): void {
+    config()->set(key: 'level-up.multiplier.enabled', value: false);
+    config()->set(key: 'level-up.audit.enabled', value: true);
+});
+
+it(description: 'adds audit data when a User level\'s up', closure: function () {
+    $this->user->addPoints(100);
+
+    expect($this->user)->experienceHistory->count()->toBe(expected: 2);
+
+    $this->assertDatabaseHas(table: 'experience_audits', data: [
+        'user_id' => $this->user->id,
+        'points' => 100,
+        'levelled_up' => true,
+        'level_to' => 2,
+        'type' => 'level_up',
+    ]);
+});

--- a/tests/Listeners/UserLevelledUpListenerTest.php
+++ b/tests/Listeners/UserLevelledUpListenerTest.php
@@ -1,5 +1,9 @@
 <?php
 
+use Illuminate\Support\Facades\Event;
+use LevelUp\Experience\Events\UserLevelledUp;
+use LevelUp\Experience\Listeners\UserLevelledUpListener;
+
 beforeEach(closure: function (): void {
     config()->set(key: 'level-up.multiplier.enabled', value: false);
     config()->set(key: 'level-up.audit.enabled', value: true);
@@ -17,4 +21,13 @@ it(description: 'adds audit data when a User level\'s up', closure: function () 
         'level_to' => 2,
         'type' => 'level_up',
     ]);
+});
+
+test(description: 'the Event and Listener run when levelling up', closure: function () {
+    Event::fake();
+
+    $this->user->addPoints(100);
+
+    Event::assertDispatched(event: UserLevelledUp::class);
+    Event::assertListening(expectedEvent: UserLevelledUp::class, expectedListener: UserLevelledUpListener::class);
 });

--- a/tests/Models/LevelTest.php
+++ b/tests/Models/LevelTest.php
@@ -7,15 +7,15 @@ uses()->group('levels');
 
 it(description: 'can create a level', closure: function (): void {
     $level = Level::add([
-        'level' => 4,
-        'next_level_experience' => 500,
+        'level' => 6,
+        'next_level_experience' => 750,
     ]);
 
-    expect(value: $level[0]->level)->toBe(expected: 4);
+    expect(value: $level[0]->level)->toBe(expected: 6);
 
     $this->assertDatabaseHas(table: 'levels', data: [
-        'level' => 4,
-        'next_level_experience' => 500,
+        'level' => 6,
+        'next_level_experience' => 750,
     ]);
 });
 

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -23,6 +23,8 @@ uses(TestCase::class, FastRefreshDatabase::class)
             ['level' => 1, 'next_level_experience' => null],
             ['level' => 2, 'next_level_experience' => 100],
             ['level' => 3, 'next_level_experience' => 250],
+            ['level' => 4, 'next_level_experience' => 400],
+            ['level' => 5, 'next_level_experience' => 600],
         );
     })
     ->in(__DIR__);


### PR DESCRIPTION
Modified the `addPoints` function in the `GiveExperience` file to calculate the user's level based on initial experience gained. Now, whenever a user gains initial experience, their level is adjusted and an event `UserLevelledUp` is dispatched if the new level is greater than the configured `starting_level`. 

Additionally, extended the `GiveExperienceTest` to cover this new functionality. This change is intended to increase code efficiency and improve user experience by giving them immediate feedback about their level as soon as they start gaining experience.

Fixes #36 