### PR TITLE
Fire Multiple Levelled Up Events

### DIFF
--- a/tests/Concerns/GiveExperienceTest.php
+++ b/tests/Concerns/GiveExperienceTest.php
@@ -257,7 +257,7 @@ test('a Users level is restored if the level cap is re-enabled and points contin
 
     expect($this->user->experience)
         ->experience_points->toBe(expected: 400)
-        ->and($this->user)->getLevel()->toBe(expected: 3);
+        ->and($this->user)->getLevel()->toBe(expected: 4);
 });
 
 test('A multiplier can use data that was passed through to it', function () {

--- a/tests/Listeners/PointsIncreasedListenerTest.php
+++ b/tests/Listeners/PointsIncreasedListenerTest.php
@@ -58,7 +58,7 @@ test(description: 'when a User levels up, a record is stored in the audit', clos
     $this->user->addPoints(amount: 100);
 
     expect($this->user)
-        ->experienceHistory()->count()->toBe(expected: 2);
+        ->experienceHistory()->count()->toBe(expected: 3);
 
     $this->assertDatabaseHas(table: 'experience_audits', data: [
         'user_id' => $this->user->id,
@@ -109,4 +109,15 @@ test(description: 'points can be added with a reason, for the audit log', closur
         'type' => AuditType::Add->value,
         'reason' => 'test',
     ]);
+});
+
+test(description: 'a User can level up multiple times', closure: function () {
+    /**
+     * Example: a new User will start with no experience, can be given
+     * 300 points, and will level up to level 3
+     */
+    $this->user->addPoints(amount: 300);
+    $this->user->addPoints(amount: 300);
+
+    expect($this->user)->getLevel()->toBe(expected: 5);
 });


### PR DESCRIPTION
Updated to appropriately fire events for each level gained and not just the final level. Removed the direct update of the user's level within the `levelUp` method and instead implemented a function to calculate and update to the highest possible level based on a user's current points. This ensures that levelling up and firing of events occur for each level achieved, rather than skipping to the final level.

Further fixes #36 