### PR TITLE
Added PointsDecreasedListener to handle points decrement

### DIFF
--- a/src/Events/PointsDecreased.php
+++ b/src/Events/PointsDecreased.php
@@ -2,6 +2,7 @@
 
 namespace LevelUp\Experience\Events;
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Events\Dispatchable;
 
 class PointsDecreased
@@ -9,8 +10,12 @@ class PointsDecreased
     use Dispatchable;
 
     public function __construct(
-        public int $pointsDecreasedBy,
-        public int $totalPoints,
-    ) {
+        public int     $pointsDeducted,
+        public int     $totalPoints,
+        public string  $type,
+        public ?string $reason,
+        public Model   $user
+    )
+    {
     }
 }

--- a/src/Listeners/PointsDecreasedListener.php
+++ b/src/Listeners/PointsDecreasedListener.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace LevelUp\Experience\Listeners;
+
+use LevelUp\Experience\Events\PointsDecreased;
+use LevelUp\Experience\Models\Level;
+
+class PointsDecreasedListener
+{
+    public function __invoke(PointsDecreased $event): void
+    {
+        /// don't create an audit record when the amount is 0
+        if ($event->pointsDeducted === 0) {
+            return;
+        }
+
+        if (config(key: 'level-up.audit.enabled')) {
+            $event->user->experienceHistory()->create([
+                'points' => -$event->pointsDeducted, // Note the negative sign to indicate points deduction
+                'type' => $event->type,
+                'reason' => $event->reason,
+            ]);
+        }
+
+        // Get the next lower level experience needed for the user's current level
+        $previousLevel = Level::firstWhere(column: 'level', operator: '=', value: $event->user->getLevel() - 1);
+
+        if (! $previousLevel) {
+            // If there is no previous level, return
+            return;
+        }
+
+        // Check if user's points are less than the current level's required experience
+        if ($event->user->getPoints() < $previousLevel->next_level_experience) {
+            // Find the lowest level the user can be demoted to with current points
+            $lowestDemotableLevel = Level::query()
+                ->where(column: 'next_level_experience', operator: '>=', value: $event->user->getPoints())
+                ->orderBy(column: 'level')
+                ->first();
+
+            // Update the user level to the lowest demotable level
+            if ($lowestDemotableLevel->level < $event->user->getLevel()) {
+                $event->user->levelDown(to: $lowestDemotableLevel->level);
+            }
+        }
+    }
+}

--- a/src/Providers/EventServiceProvider.php
+++ b/src/Providers/EventServiceProvider.php
@@ -3,8 +3,10 @@
 namespace LevelUp\Experience\Providers;
 
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
+use LevelUp\Experience\Events\PointsDecreased;
 use LevelUp\Experience\Events\PointsIncreased;
 use LevelUp\Experience\Events\UserLevelledUp;
+use LevelUp\Experience\Listeners\PointsDecreasedListener;
 use LevelUp\Experience\Listeners\PointsIncreasedListener;
 use LevelUp\Experience\Listeners\UserLevelledUpListener;
 
@@ -16,6 +18,9 @@ class EventServiceProvider extends ServiceProvider
         ],
         UserLevelledUp::class => [
             UserLevelledUpListener::class,
+        ],
+        PointsDecreased::class => [
+            PointsDecreasedListener::class,
         ],
     ];
 

--- a/tests/Listeners/PointsDecreasedListenerTest.php
+++ b/tests/Listeners/PointsDecreasedListenerTest.php
@@ -1,0 +1,82 @@
+<?php
+
+use Illuminate\Support\Facades\Event;
+use LevelUp\Experience\Enums\AuditType;
+use LevelUp\Experience\Events\PointsDecreased;
+use LevelUp\Experience\Listeners\PointsDecreasedListener;
+
+beforeEach(closure: function (): void {
+    config()->set(key: 'level-up.multiplier.enabled', value: false);
+});
+
+uses()->group('experience');
+
+test(description: 'the Event and Listener run when points are deducted from a User Model', closure: function (): void {
+    Event::fakeFor(callable: function (): void {
+        // this creates the experience Model
+        $this->user->addPoints(amount: 20);
+        // so now it will decrement the points
+        $this->user->deductPoints(amount: 10);
+
+        Event::assertDispatched(event: PointsDecreased::class);
+        Event::assertListening(expectedEvent: PointsDecreased::class, expectedListener: PointsDecreasedListener::class);
+    });
+});
+
+test(description: 'deducting points creates an audit record', closure: function (): void {
+    config()->set(key: 'level-up.audit.enabled', value: true);
+
+    $this->user->addPoints(amount: 20);
+    $this->user->deductPoints(amount: 10);
+
+    expect($this->user)
+        ->experienceHistory()->count()->toBe(expected: 2);
+
+    $this->assertDatabaseHas(table: 'experience_audits', data: [
+        'user_id' => $this->user->id,
+        'points' => -10,
+        'levelled_up' => false,
+        'level_to' => null,
+        'type' => AuditType::Remove->value,
+        'reason' => null,
+    ]);
+});
+
+test(description: 'deducting points does not create an audit record when disabled', closure: function (): void {
+    config()->set(key: 'level-up.audit.enabled', value: false);
+
+    $this->user->addPoints(amount: 20);
+    $this->user->deductPoints(amount: 10);
+
+    expect($this->user)
+        ->experienceHistory()->count()->toBe(expected: 0);
+});
+
+test(description: 'deducting points does not create an audit record when the amount is 0', closure: function (): void {
+    config()->set(key: 'level-up.audit.enabled', value: true);
+
+    $this->user->addPoints(amount: 20);
+    $this->user->deductPoints(amount: 0);
+
+    expect($this->user)
+        ->experienceHistory()->count()->toBe(expected: 1);
+});
+
+test(description: 'deducting points creates an audit record with a reason', closure: function (): void {
+    config()->set(key: 'level-up.audit.enabled', value: true);
+
+    $this->user->addPoints(amount: 20);
+    $this->user->deductPoints(amount: 10, reason: 'test');
+
+    expect($this->user)
+        ->experienceHistory()->count()->toBe(expected: 2);
+
+    $this->assertDatabaseHas(table: 'experience_audits', data: [
+        'user_id' => $this->user->id,
+        'points' => -10,
+        'levelled_up' => false,
+        'level_to' => null,
+        'type' => AuditType::Remove->value,
+        'reason' => 'test',
+    ]);
+});


### PR DESCRIPTION
### Title:
Add PointsDecreasedListener and Update GiveExperience Trait

### Description:
This PR addresses issue [#44](https://github.com/cjmellor/level-up/issues/44) by adding a new listener for points decrement (PointsDecreasedListener) and updating the GiveExperience trait to handle point deductions more effectively.

#### Changes:

1. Added **PointsDecreasedListener** to handle the **PointsDecreased** event.
2. Refactored **PointsDecreased** event to include **type**, **reason**, and **user**.
3. Updated **GiveExperience** trait with a **deductPoints** method that accepts **type** and **reason** parameters.
4. Added unit tests for **PointsDecreasedListener**.

#### How to Test:

1. Run the unit tests to ensure all new and existing tests pass.
2. Manually test the points deduction feature to ensure it works as expected.