### PR TITLE
Add Listener for PointsDecreased Event

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,11 +1,6 @@
 name: "Run Tests"
-on:
-  push:
-    branches:
-      - 'main'
-  pull_request:
-    branches:
-      - '*'
+
+on: pull_request
 
 jobs:
   tests:
@@ -17,7 +12,7 @@ jobs:
         laravel: [ 10 ]
         stability: [ prefer-lowest, prefer-stable ]
 
-    name: "PHP: v${{ matrix.php }} / Laravel: v${{ matrix.laravel }} - ${{ matrix.stability }}"
+    name: "PHP: v${{ matrix.php }} [${{ matrix.stability }}]"
 
     steps:
       - name: Checkout
@@ -40,4 +35,4 @@ jobs:
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: Execute tests
-        run: vendor/bin/pest
+        run: vendor/bin/pest --parallel

--- a/README.md
+++ b/README.md
@@ -282,6 +282,8 @@ public Model $user,
 ```php
 public int $pointsDecreasedBy,
 public int $totalPoints,
+public ?string $reason,
+public Model $user,
 ```
 
 ## ⬆️ Levelling
@@ -510,6 +512,10 @@ $user->addPoints(
     reason: "Some reason here",
 );
 ```
+
+> **Note**
+> 
+> Auditing happens when the `addPoints` and `deductPoints` methods are called. Auditing must be enabled in the config file.
 
 **View a Users’ Audit Experience**
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,14 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.1/phpunit.xsd" bootstrap="vendor/autoload.php" colors="true" cacheDirectory=".phpunit.cache">
+<phpunit
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.1/phpunit.xsd"
+        bootstrap="vendor/autoload.php"
+        colors="true"
+>
     <testsuites>
         <testsuite name="Test Suite">
-            <directory suffix="Test.php">./tests</directory>
+            <directory>./tests</directory>
         </testsuite>
     </testsuites>
     <coverage/>
     <source>
         <include>
-            <directory suffix=".php">./src</directory>
+            <directory>./src</directory>
         </include>
     </source>
 </phpunit>

--- a/src/Concerns/GiveExperience.php
+++ b/src/Concerns/GiveExperience.php
@@ -134,11 +134,20 @@ trait GiveExperience
         return $this->hasMany(related: ExperienceAudit::class);
     }
 
-    public function deductPoints(int $amount): Experience
+    public function deductPoints(int $amount, string $reason = null): Experience
     {
+        if ($this->experience()->doesntExist()) {
+            return $this->experience;
+        }
+
         $this->experience->decrement(column: 'experience_points', amount: $amount);
 
-        event(new PointsDecreased(pointsDecreasedBy: $amount, totalPoints: $this->experience->experience_points));
+        event(new PointsDecreased(
+            pointsDecreasedBy: $amount,
+            totalPoints: $this->experience->experience_points,
+            reason: $reason,
+            user: $this,
+        ));
 
         return $this->experience;
     }

--- a/src/Events/PointsDecreased.php
+++ b/src/Events/PointsDecreased.php
@@ -2,6 +2,7 @@
 
 namespace LevelUp\Experience\Events;
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Events\Dispatchable;
 
 class PointsDecreased
@@ -11,6 +12,8 @@ class PointsDecreased
     public function __construct(
         public int $pointsDecreasedBy,
         public int $totalPoints,
+        public ?string $reason,
+        public Model $user,
     ) {
     }
 }

--- a/src/Listeners/PointsDecreasedListener.php
+++ b/src/Listeners/PointsDecreasedListener.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace LevelUp\Experience\Listeners;
+
+use LevelUp\Experience\Enums\AuditType;
+use LevelUp\Experience\Events\PointsDecreased;
+
+class PointsDecreasedListener
+{
+    public function __invoke(PointsDecreased $event): void
+    {
+        if ($event->pointsDecreasedBy === 0) {
+            return;
+        }
+
+        if (config(key: 'level-up.audit.enabled')) {
+            $event->user->experienceHistory()->create(attributes: [
+                'points' => $event->pointsDecreasedBy,
+                'type' => AuditType::Remove->value,
+                'reason' => $event->reason,
+            ]);
+        }
+    }
+}

--- a/src/Providers/EventServiceProvider.php
+++ b/src/Providers/EventServiceProvider.php
@@ -3,14 +3,19 @@
 namespace LevelUp\Experience\Providers;
 
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
+use LevelUp\Experience\Events\PointsDecreased;
 use LevelUp\Experience\Events\PointsIncreased;
 use LevelUp\Experience\Events\UserLevelledUp;
+use LevelUp\Experience\Listeners\PointsDecreasedListener;
 use LevelUp\Experience\Listeners\PointsIncreasedListener;
 use LevelUp\Experience\Listeners\UserLevelledUpListener;
 
 class EventServiceProvider extends ServiceProvider
 {
     protected $listen = [
+        PointsDecreased::class => [
+            PointsDecreasedListener::class,
+        ],
         PointsIncreased::class => [
             PointsIncreasedListener::class,
         ],

--- a/tests/Listeners/PointsDecreasedListenerTest.php
+++ b/tests/Listeners/PointsDecreasedListenerTest.php
@@ -1,0 +1,60 @@
+<?php
+
+use Illuminate\Support\Facades\Event;
+use LevelUp\Experience\Events\PointsDecreased;
+use LevelUp\Experience\Listeners\PointsDecreasedListener;
+
+uses()->group('experience');
+
+beforeEach(closure: fn () => config()->set(key: 'level-up.multiplier.enabled', value: false));
+
+test(description: 'the Event is dispatched when points are decreased', closure: function () {
+    Event::fakeFor(function () {
+        $this->user->addPoints(amount: 100);
+        $this->user->deductPoints(amount: 50, reason: 'test');
+
+        Event::assertDispatched(event: PointsDecreased::class, callback: function ($event): bool {
+            return $event->pointsDecreasedBy === 50
+                && $event->reason === 'test';
+        });
+        Event::assertListening(expectedEvent: PointsDecreased::class, expectedListener: PointsDecreasedListener::class);
+    });
+});
+
+test(description: 'the Event Listener runs and logs the audit', closure: function () {
+    config()->set(key: 'level-up.audit.enabled', value: true);
+    config()->set(key: 'level-up.multiplier.enabled', value: false);
+
+    $this->user->addPoints(amount: 100);
+    $this->user->deductPoints(amount: 50, reason: 'test');
+
+    $this->assertDatabaseHas(table: 'experience_audits', data: [
+        'points' => 50,
+        'type' => 'remove',
+        'reason' => 'test',
+    ]);
+});
+
+test(description: 'deducting points does not create an audit record when disabled', closure: function (): void {
+    config()->set(key: 'level-up.audit.enabled', value: false);
+
+    $this->user->addPoints(amount: 20);
+    $this->user->deductPoints(amount: 10);
+
+    expect($this->user)
+        ->experienceHistory()
+        ->count()
+        ->toBe(expected: 0);
+});
+
+test(description: 'deducting points does not create an audit record when the amount is 0', closure: function (): void {
+    config()->set(key: 'level-up.audit.enabled', value: true);
+
+    $this->user->addPoints(amount: 20);
+    $this->user->deductPoints(amount: 0);
+
+    expect($this->user)
+        ->experienceHistory()
+        ->count()
+        ->toBe(expected: 1);
+});


### PR DESCRIPTION
This PR achieves the following:

- Adds a new Listener for the `PointsDecreased` event which will add a record to the audit log if it is enabled.

Closes #44 

Big thanks to @mohamedalwhaidi who also did a PR based on his original issue (#44) while I was doing this. I took some of his suggestions and implemented them into my PR. Thanks!