### PR TITLE
feat: Conditional Multipliers

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,16 @@ public function qualifies(array $data): bool
 }
 ```
 
+**Conditional Multipliers**
+
+If you don't want to use the class based method to check conditionals to add multipliers, you can do this inline by giving the method a callback with the conditional. When using this method, make sure you have the multiplier set as an argument in the `addPoints` method, otherwise an error will occur. See example below:
+
+```php
+$user
+    ->withMultiplierData(fn () => true)
+    ->addPoints(amount: 10, multiplier: 2);
+```
+
 The `setMultiplier` method expects an `int` which is the number it will be multiplied by.
 
 **Multiply Manually**

--- a/src/Concerns/GiveExperience.php
+++ b/src/Concerns/GiveExperience.php
@@ -49,7 +49,7 @@ trait GiveExperience
         }
 
         if ($this->multiplierCondition instanceof \Closure && is_null($multiplier)) {
-            throw new InvalidArgumentException(message: "Multiplier is not set");
+            throw new InvalidArgumentException(message: 'Multiplier is not set');
         }
 
         if (isset($this->multiplierCondition) && ! ($this->multiplierCondition)()) {

--- a/src/Concerns/GiveExperience.php
+++ b/src/Concerns/GiveExperience.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Event;
+use InvalidArgumentException;
 use LevelUp\Experience\Enums\AuditType;
 use LevelUp\Experience\Events\PointsDecreased;
 use LevelUp\Experience\Events\PointsIncreased;
@@ -45,6 +46,10 @@ trait GiveExperience
          */
         if (config(key: 'level-up.multiplier.enabled') && file_exists(filename: config(key: 'level-up.multiplier.path'))) {
             $amount = $this->getMultipliers(amount: $amount);
+        }
+
+        if ($this->multiplierCondition instanceof \Closure && is_null($multiplier)) {
+            throw new InvalidArgumentException(message: "Multiplier is not set");
         }
 
         if (isset($this->multiplierCondition) && ! ($this->multiplierCondition)()) {
@@ -179,7 +184,7 @@ trait GiveExperience
         return $this->experience;
     }
 
-    public function withMultiplierData($data): static
+    public function withMultiplierData(array|callable $data): static
     {
         if ($data instanceof Closure) {
             $this->multiplierCondition = $data;

--- a/tests/Concerns/GiveExperienceTest.php
+++ b/tests/Concerns/GiveExperienceTest.php
@@ -271,7 +271,7 @@ test('a Users level is restored if the level cap is re-enabled and points contin
         ->and($this->user)->getLevel()->toBe(expected: 4);
 });
 
-test('A multiplier can use data that was passed through to it', function () {
+test('A multiplier can use data that was passed through to it', closure: function () {
     config()->set(key: 'level-up.multiplier.enabled', value: true);
     config()->set(key: 'level-up.multiplier.path', value: 'tests/Fixtures/Multipliers');
     config()->set(key: 'level-up.multiplier.namespace', value: 'LevelUp\\Experience\\Tests\\Fixtures\\Multipliers\\');
@@ -291,6 +291,27 @@ test('A multiplier can use data that was passed through to it', function () {
         'level_id' => 1,
         'experience_points' => 50,
     ]);
+});
+
+test(description: 'an anonymous function can be used as a multiplier condition', closure: function () {
+    $this->user
+        ->withMultiplierData(fn () => true)
+        ->addPoints(amount: 10, multiplier: 2);
+
+    expect($this->user)
+        ->experience->experience_points->toBe(expected: 20)
+        ->and($this->user)->experience->toBeInstanceOf(class: Experience::class);
+
+    /*
+     * Check the opposite of the above -- if condition is false, multiplier should not be applied
+     * */
+    $this->user
+        ->withMultiplierData(fn () => false)
+        ->addPoints(amount: 10, multiplier: 2);
+
+    expect($this->user)
+        ->experience->experience_points->toBe(expected: 30)
+        ->and($this->user)->experience->toBeInstanceOf(class: Experience::class);
 });
 
 test(description: 'Add default level if not applied before trying to add points', closure: function () {

--- a/tests/Concerns/GiveExperienceTest.php
+++ b/tests/Concerns/GiveExperienceTest.php
@@ -314,6 +314,10 @@ test(description: 'an anonymous function can be used as a multiplier condition',
         ->and($this->user)->experience->toBeInstanceOf(class: Experience::class);
 });
 
+test(description: 'a multiplier must be added when using multiplier closures')
+    ->defer(fn () => $this->user->withMultiplierData(fn () => true)->addPoints(amount: 10))
+    ->throws(exception: InvalidArgumentException::class, exceptionMessage: 'Multiplier is not set');
+
 test(description: 'Add default level if not applied before trying to add points', closure: function () {
     // In this scenario, no Level Model should be applied to the User, so the default level should be applied
     Level::truncate();


### PR DESCRIPTION
This PR adds a new feature where you can conditionally add multipliers.

You might not want to use Multipliers via a Class, so now you can add an anonymous function to the `withMultiplerData` method and multiply data that way.

Example:

```php
$user
    ->withMultiplierData(fn () => true)
    ->addPoints(amount: 100, multiplier: 10);
```

The original way of doing it via classes is still functional.