### PR TITLE
Fixed one migration problem and  null level handling in getLevel() & getPoints(),  causing some error

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -11,5 +11,6 @@ Now run `php artisan vendor:publish` and select `LevelUp\Experience\LevelUpServi
 This also publishes new migration files. Run `php artisan migrate` to migrate the new tables.
 
 Important Note
+
 A new migration is required to accommodate the ended_at column becoming nullable. This migration should alter the table schema to allow NULL values for the ended_at column. Ensure data integrity during this process.
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -9,3 +9,6 @@ Some new configuration settings have been introduced. Delete the `config/level-u
 Now run `php artisan vendor:publish` and select `LevelUp\Experience\LevelUpServiceProvider`
 
 This also publishes new migration files. Run `php artisan migrate` to migrate the new tables.
+
+Important Note
+A new migration is required to accommodate the ended_at column becoming nullable. This migration should alter the table schema to allow NULL values for the ended_at column. Ensure data integrity during this process.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -10,7 +10,41 @@ Now run `php artisan vendor:publish` and select `LevelUp\Experience\LevelUpServi
 
 This also publishes new migration files. Run `php artisan migrate` to migrate the new tables.
 
-Important Note
 
-A new migration is required to accommodate the ended_at column becoming nullable. This migration should alter the table schema to allow NULL values for the ended_at column. Ensure data integrity during this process.
 
+#### New Migration for Nullable ended_at Column
+
+In version `v0.0.7`, a new migration is introduced to make the `ended_at` column in the `streak_histories` table nullable. This change allows flexibility in recording the end time of streaks.
+
+To apply this migration:
+
+1. Locate the migration file responsible for creating the `streak_histories` table. This file should be named something like `YYYY_MM_DD_HHMMSS_create_streak_histories_table.php`.
+
+2. Open the migration file and add the following code inside the `up` method:
+
+```php
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('streak_histories', function (Blueprint $table) {
+            $table->timestamp('ended_at')->nullable()->change();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('streak_histories', function (Blueprint $table) {
+            $table->dropColumn('ended_at');
+        });
+    }
+};
+
+
+```

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -12,3 +12,4 @@ This also publishes new migration files. Run `php artisan migrate` to migrate th
 
 Important Note
 A new migration is required to accommodate the ended_at column becoming nullable. This migration should alter the table schema to allow NULL values for the ended_at column. Ensure data integrity during this process.
+

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,20 +1,10 @@
-# Ugrade Guide
+# Upgrade Guide
 
-## v0.0.6 -> v0.0.7
+## v1.2.2 -> v1.2.3
 
-v0.0.7 comes with a brand-new feature -- Streaks.
+#### New Migration for Nullable `ended_at` Column
 
-Some new configuration settings have been introduced. Delete the `config/level-up.php` file.
-
-Now run `php artisan vendor:publish` and select `LevelUp\Experience\LevelUpServiceProvider`
-
-This also publishes new migration files. Run `php artisan migrate` to migrate the new tables.
-
-
-
-#### New Migration for Nullable ended_at Column
-
-In version `v0.0.7`, a new migration is introduced to make the `ended_at` column in the `streak_histories` table nullable. This change allows flexibility in recording the end time of streaks.
+In version `v1.2.3`, a new migration is introduced to make the `ended_at` column in the `streak_histories` table nullable. This change allows flexibility in recording the end time of streaks.
 
 To apply this migration:
 
@@ -45,6 +35,14 @@ return new class extends Migration
         });
     }
 };
-
-
 ```
+
+## v0.0.6 -> v0.0.7
+
+v0.0.7 comes with a brand-new feature -- Streaks.
+
+Some new configuration settings have been introduced. Delete the `config/level-up.php` file.
+
+Now run `php artisan vendor:publish` and select `LevelUp\Experience\LevelUpServiceProvider`
+
+This also publishes new migration files. Run `php artisan migrate` to migrate the new tables.

--- a/database/migrations/create_streak_histories_table.php.stub
+++ b/database/migrations/create_streak_histories_table.php.stub
@@ -15,7 +15,7 @@ return new class extends Migration
             $table->foreignIdFor(model: Activity::class)->constrained(table: 'streak_activities');
             $table->integer(column: 'count')->default(value: 1);
             $table->timestamp(column: 'started_at');
-            $table->timestamp(column: 'ended_at');
+            $table->timestamp(column: 'ended_at')->nullable();
             $table->timestamps();
         });
     }

--- a/src/Concerns/GiveExperience.php
+++ b/src/Concerns/GiveExperience.php
@@ -52,7 +52,7 @@ trait GiveExperience
             throw new InvalidArgumentException(message: 'Multiplier is not set');
         }
 
-        if (isset($this->multiplierCondition) && ! ($this->multiplierCondition)()) {
+        if (isset($this->multiplierCondition) && !($this->multiplierCondition)()) {
             $multiplier = 1;
         }
 
@@ -106,7 +106,7 @@ trait GiveExperience
 
     protected function getMultipliers(int $amount): int
     {
-        if (isset($this->multiplierCondition) && ! ($this->multiplierCondition)()) {
+        if (isset($this->multiplierCondition) && !($this->multiplierCondition)()) {
             return $amount;
         }
 
@@ -137,12 +137,12 @@ trait GiveExperience
     {
         return config(key: 'level-up.level_cap.enabled')
             && $this->getLevel() >= config(key: 'level-up.level_cap.level')
-            && ! (config(key: 'level-up.level_cap.points_continue'));
+            && !(config(key: 'level-up.level_cap.points_continue'));
     }
 
     public function getLevel(): int
     {
-        return $this->experience->status->level ?? 0;
+        return $this->experience?->status?->level ?? 0;
     }
 
     public function experienceHistory(): HasMany
@@ -173,7 +173,7 @@ trait GiveExperience
      */
     public function setPoints(int $amount): Experience
     {
-        if (! $this->experience()->exists()) {
+        if (!$this->experience()->exists()) {
             throw new Exception(message: 'User has no experience record.');
         }
 
@@ -203,7 +203,7 @@ trait GiveExperience
             return 0;
         }
 
-        if (! $nextLevel || $nextLevel->next_level_experience === null) {
+        if (!$nextLevel || $nextLevel->next_level_experience === null) {
             return 0;
         }
 
@@ -218,7 +218,7 @@ trait GiveExperience
 
     public function getPoints(): int
     {
-        return $this->experience->experience_points ?? 0;
+        return $this->experience?->experience_points ?? 0;
     }
 
     public function levelUp(int $to): void

--- a/src/Concerns/GiveExperience.php
+++ b/src/Concerns/GiveExperience.php
@@ -52,7 +52,7 @@ trait GiveExperience
             throw new InvalidArgumentException(message: 'Multiplier is not set');
         }
 
-        if (isset($this->multiplierCondition) && !($this->multiplierCondition)()) {
+        if (isset($this->multiplierCondition) && ! ($this->multiplierCondition)()) {
             $multiplier = 1;
         }
 
@@ -106,7 +106,7 @@ trait GiveExperience
 
     protected function getMultipliers(int $amount): int
     {
-        if (isset($this->multiplierCondition) && !($this->multiplierCondition)()) {
+        if (isset($this->multiplierCondition) && ! ($this->multiplierCondition)()) {
             return $amount;
         }
 
@@ -137,7 +137,7 @@ trait GiveExperience
     {
         return config(key: 'level-up.level_cap.enabled')
             && $this->getLevel() >= config(key: 'level-up.level_cap.level')
-            && !(config(key: 'level-up.level_cap.points_continue'));
+            && ! (config(key: 'level-up.level_cap.points_continue'));
     }
 
     public function getLevel(): int
@@ -173,7 +173,7 @@ trait GiveExperience
      */
     public function setPoints(int $amount): Experience
     {
-        if (!$this->experience()->exists()) {
+        if (! $this->experience()->exists()) {
             throw new Exception(message: 'User has no experience record.');
         }
 
@@ -203,7 +203,7 @@ trait GiveExperience
             return 0;
         }
 
-        if (!$nextLevel || $nextLevel->next_level_experience === null) {
+        if (! $nextLevel || $nextLevel->next_level_experience === null) {
             return 0;
         }
 

--- a/src/Concerns/GiveExperience.php
+++ b/src/Concerns/GiveExperience.php
@@ -142,7 +142,7 @@ trait GiveExperience
 
     public function getLevel(): int
     {
-        return $this->experience->status->level;
+        return $this->experience->status->level ?? 0;
     }
 
     public function experienceHistory(): HasMany
@@ -218,7 +218,7 @@ trait GiveExperience
 
     public function getPoints(): int
     {
-        return $this->experience->experience_points;
+        return $this->experience->experience_points ?? 0;
     }
 
     public function levelUp(int $to): void

--- a/src/Concerns/GiveExperience.php
+++ b/src/Concerns/GiveExperience.php
@@ -92,7 +92,6 @@ trait GiveExperience
 
         /**
          * If the User does have an Experience record, update it.
-         * 
          */
         if ($this->levelCapExceedsUserLevel()) {
             return $this->experience;

--- a/src/Concerns/GiveExperience.php
+++ b/src/Concerns/GiveExperience.php
@@ -92,6 +92,7 @@ trait GiveExperience
 
         /**
          * If the User does have an Experience record, update it.
+         * 
          */
         if ($this->levelCapExceedsUserLevel()) {
             return $this->experience;

--- a/tests/Concerns/GiveExperienceTest.php
+++ b/tests/Concerns/GiveExperienceTest.php
@@ -375,13 +375,13 @@ beforeEach(function (): void {
 });
 
 it('returns 0 when level is not set', function (): void {
-    $this->user->experience = null; // Simulating a user with no experience model
+    $this->user->experience = null; 
 
     expect($this->user->getLevel())->toBe(0);
 });
 
 it('returns 0 when experience points are not set', function (): void {
-    $this->user->experience = null; // Simulating a user with no experience model
+    $this->user->experience = null; 
 
     expect($this->user->getPoints())->toBe(0);
 });

--- a/tests/Concerns/GiveExperienceTest.php
+++ b/tests/Concerns/GiveExperienceTest.php
@@ -369,3 +369,19 @@ it(description: 'dispatches an event after points have been added for the very f
 
     Event::assertDispatched(event: UserLevelledUp::class);
 });
+
+beforeEach(function (): void {
+    config()->set('level-up.multiplier.enabled', false);
+});
+
+it('returns 0 when level is not set', function (): void {
+    $this->user->experience = null; // Simulating a user with no experience model
+
+    expect($this->user->getLevel())->toBe(0);
+});
+
+it('returns 0 when experience points are not set', function (): void {
+    $this->user->experience = null; // Simulating a user with no experience model
+
+    expect($this->user->getPoints())->toBe(0);
+});

--- a/tests/Concerns/GiveExperienceTest.php
+++ b/tests/Concerns/GiveExperienceTest.php
@@ -370,18 +370,14 @@ it(description: 'dispatches an event after points have been added for the very f
     Event::assertDispatched(event: UserLevelledUp::class);
 });
 
-beforeEach(function (): void {
-    config()->set('level-up.multiplier.enabled', false);
-});
-
 it('returns 0 when level is not set', function (): void {
-    $this->user->experience = null; 
+    $this->user->experience = null;
 
     expect($this->user->getLevel())->toBe(0);
 });
 
 it('returns 0 when experience points are not set', function (): void {
-    $this->user->experience = null; 
+    $this->user->experience = null;
 
     expect($this->user->getPoints())->toBe(0);
 });

--- a/tests/Concerns/HasStreaksTest.php
+++ b/tests/Concerns/HasStreaksTest.php
@@ -7,7 +7,6 @@ use LevelUp\Experience\Events\StreakIncreased;
 use LevelUp\Experience\Events\StreakStarted;
 use LevelUp\Experience\Events\StreakUnfroze;
 use LevelUp\Experience\Models\Activity;
-
 use function Pest\Laravel\travel;
 
 uses()->group('streaks');


### PR DESCRIPTION
## Description

### 1st Issue
When there is no experience record yet and `getPoints()` is executed, it returns the following error message:
```
App\Models\User::getPoints(): Return value must be of type int, null returned.
```
This issue was addressed by modifying two functions as follows:
```php
//src/Concerns/GiveExperience.php
public function getLevel(): int
{
    return $this->experience->status->level ?? 0;
}

public function getPoints(): int
{
    return $this->experience->experience_points ?? 0;
}
```

### 2nd Issue
During migration, the following SQL error was encountered:
```SQL
SQLSTATE[42000]: Syntax error or access violation: 1067 Invalid default value for 'ended_at' (Connection: mysql, SQL: 
create table `streak_histories` (`id` bigint unsigned not null auto_increment primary key, `user_id` bigint unsigned not 
null, `activity_id` bigint unsigned not null, `count` int not null default '1', `started_at` timestamp not null, `ended_at` 
timestamp not null, `created_at` timestamp null, `updated_at` timestamp null) default character set utf8mb4 collate 
'utf8mb4_unicode_ci')
```
This issue was resolved by adding a nullable constraint to the `ended_at` column in the migration script:
```php
//database/migrations/create_streak_histories_table.php.stub
Schema::create('streak_histories', function (Blueprint $table) {
    $table->id();
    $table->foreignId('user_id')->constrained('users')->cascadeOnDelete();
    $table->foreignId('activity_id')->constrained('streak_activities');
    $table->integer('count')->default(1);
    $table->timestamp('started_at');
    $table->timestamp('ended_at')->nullable(); // Nullable constraint added
    $table->timestamps();
});
```

## Type of Change
- Bug fix 

## Related Issues
- Issue  [#57](https://github.com/cjmellor/level-up/issues/57)

---
