### PR TITLE
fix: migrations roll back

### DIFF
--- a/database/migrations/create_experiences_table.php.stub
+++ b/database/migrations/create_experiences_table.php.stub
@@ -16,4 +16,9 @@ return new class extends Migration
             $table->timestamps();
         });
     }
+
+    public function down()
+    {
+        Schema::dropIfExists(config('level-up.table'));
+    }
 };


### PR DESCRIPTION
## Description
I have added the down method to delete the 'experiences' table, as without this method, migrations cannot be reverted.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update