### PR TITLE
fix: custom experiences table

### DIFF
--- a/src/Models/Experience.php
+++ b/src/Models/Experience.php
@@ -10,6 +10,12 @@ class Experience extends Model
 {
     // use HasFactory;
 
+    public function __construct(array $attributes = [])
+    {
+        parent::__construct($attributes);
+        $this->table = config(key: 'level-up.table');
+    }
+
     protected $guarded = [];
 
     public function user(): BelongsTo


### PR DESCRIPTION
## Description
The Experience Model was not using the table name defined in the configuration.

## Steps to reproduce
Change the default value of 'experiences' to another one and try to add points to a user. The following error will be thrown: "Base table or view not found: 1146 Table 'experiences' doesn't exist"


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing
If you think it would be interesting to add some tests, you could add them or let me know how you would like to integrate them into the current test suite?

Thanks!
