### PR TITLE
fix Remove 'level_id' migration

### DIFF
--- a/database/migrations/remove_level_id_column_from_users_table.php.stub
+++ b/database/migrations/remove_level_id_column_from_users_table.php.stub
@@ -7,15 +7,15 @@ use Illuminate\Support\Facades\Schema;
 return new class extends Migration {
     public function up(): void
     {
-        Schema::table('users', function (Blueprint $table) {
-            $table->dropColumn('level_id');
+        Schema::table(config('level-up.user.users_table'), function (Blueprint $table) {
+            $table->dropConstrainedForeignId('level_id');
         });
     }
 
     public function down(): void
     {
-        Schema::table('users', function (Blueprint $table) {
-            $table->foreignId('level_id')->constrained();
+        Schema::table(config('level-up.user.users_table'), function (Blueprint $table) {
+            $table->foreignId('level_id')->nullable()->constrained();
         });
     }
 };


### PR DESCRIPTION
## Description
The migration introduced in the PR #75 cannot be executed because the 'level_id' field contains a foreign key constraint preventing the field from being removed.
Additionally, it was not taken into account that the user may have modified the 'users' table in the configuration file.
This PR aims to fix these 2 issues.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Related Issues and Pull Requests

- https://github.com/cjmellor/level-up/pull/75

## Testing

Please provide a passing test where possible. This package uses [PestPHP](https://pestphp.com)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have made corresponding changes to the documentation [OPTIONAL]
