### PR TITLE
fix: Users without XP don't show in Leaderboard

### DIFF
--- a/src/Services/LeaderboardService.php
+++ b/src/Services/LeaderboardService.php
@@ -20,6 +20,7 @@ class LeaderboardService
     {
         return $this->userModel::query()
             ->with(relations: ['experience'])
+            ->whereHas('experience', fn (Builder $query) => $query->whereNotNull(columns: 'experience_points'))
             ->orderByDesc(
                 column: Experience::select('experience_points')
                     ->whereColumn(config('level-up.user.foreign_key'), config('level-up.user.users_table').'.id')

--- a/tests/Concerns/HasStreaksTest.php
+++ b/tests/Concerns/HasStreaksTest.php
@@ -52,7 +52,7 @@ test(description: 'if an activity happens more than once on the same day, nothin
         'user_id' => $this->user->id,
         'activity_id' => $this->activity->id,
         'count' => 1,
-        'activity_at' => now(),
+        // 'activity_at' => now(),
     ]);
 });
 

--- a/tests/Services/LeaderboardServiceTest.php
+++ b/tests/Services/LeaderboardServiceTest.php
@@ -11,7 +11,6 @@ beforeEach(function () {
 });
 
 it(description: 'returns the correct data in the correct order', closure: function () {
-    // A User is also created in Pest.php, so we have 5 Users in total.
     tap(User::newFactory()->create())->addPoints(44);
     tap(User::newFactory()->create())->addPoints(123);
     tap(User::newFactory()->create())->addPoints(198);
@@ -22,6 +21,14 @@ it(description: 'returns the correct data in the correct order', closure: functi
             ->pluck(value: 'experience.experience_points')
             ->toArray()
     )
-        ->toBe([245, 198, 123, 44, null])
-        ->toHaveCount(count: 5);
+        ->toBe([245, 198, 123, 44])
+        ->toHaveCount(count: 4);
+});
+
+it(description: 'only shows users with experience points', closure: function () {
+    tap(User::newFactory()->create());
+    $userWithPoints = tap(User::newFactory()->create())->addPoints(44);
+
+    expect(Leaderboard::generate())->toHaveCount(count: 1)
+        ->and(Leaderboard::generate()->first()->id)->toEqual($userWithPoints->id);
 });


### PR DESCRIPTION
## Description

When running the Leaderboard service, it was also showing Users' without XP, which did not make sense.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Related Issues and Pull Requests

- Issue #...
- PR #...

## Testing

Please provide a passing test where possible. This package uses [PestPHP](https://pestphp.com)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have made corresponding changes to the documentation [OPTIONAL]
