### PR TITLE
fix: Creating new experience issue

### DIFF
--- a/src/Concerns/GiveExperience.php
+++ b/src/Concerns/GiveExperience.php
@@ -64,11 +64,14 @@ trait GiveExperience
          */
         if ($this->experience()->doesntExist()) {
             $level = Level::query()
-                ->firstWhere(column: 'next_level_experience', operator: '<=', value: $amount)
-                ->orderByDesc(column: 'next_level_experience');
+                ->where(column: 'next_level_experience', operator: '<=', value: $amount)
+                ->orderByDesc(column: 'next_level_experience')
+                ->first();
 
             if ($level === null) {
-                $level = Level::firstWhere(column: 'level', operator: '=', value: config(key: 'level-up.starting_level'));
+                $level = Level::query()
+                    ->where(column: 'level', operator: '=', value: config(key: 'level-up.starting_level'))
+                    ->first();
             }
 
             $experience = $this->experience()->create(attributes: [

--- a/src/Concerns/GiveExperience.php
+++ b/src/Concerns/GiveExperience.php
@@ -64,14 +64,11 @@ trait GiveExperience
          */
         if ($this->experience()->doesntExist()) {
             $level = Level::query()
-                ->where(column: 'next_level_experience', operator: '<=', value: $amount)
-                ->orderByDesc(column: 'next_level_experience')
-                ->first();
+                ->firstWhere(column: 'next_level_experience', operator: '<=', value: $amount)
+                ->orderByDesc(column: 'next_level_experience');
 
             if ($level === null) {
-                $level = Level::query()
-                    ->where(column: 'level', operator: '=', value: config(key: 'level-up.starting_level'))
-                    ->first();
+                $level = Level::firstWhere(column: 'level', operator: '=', value: config(key: 'level-up.starting_level'));
             }
 
             $experience = $this->experience()->create(attributes: [

--- a/src/Concerns/GiveExperience.php
+++ b/src/Concerns/GiveExperience.php
@@ -68,8 +68,14 @@ trait GiveExperience
                 ->orderByDesc(column: 'next_level_experience')
                 ->first();
 
+            if ($level === null) {
+                $level = Level::query()
+                    ->where(column: 'level', operator: '=', value: config(key: 'level-up.starting_level'))
+                    ->first();
+            }
+
             $experience = $this->experience()->create(attributes: [
-                'level_id' => $level->level ?? config(key: 'level-up.starting_level'),
+                'level_id' => $level->id,
                 'experience_points' => $amount,
             ]);
 


### PR DESCRIPTION
## Description

Fix: Ensure Level ID is retrieved when adding points in GiveExperience trait

When the addPoints method in the GiveExperience trait is executed, it creates a new Experience. If the condition for the Level query returns null, the default level is retrieved from the config file. This update ensures that the Level ID is correctly retrieved in such cases.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Related Issues and Pull Requests

- Issue #...
- PR #...

## Testing

Please provide a passing test where possible. This package uses [PestPHP](https://pestphp.com)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x ] New and existing unit tests pass locally with my changes
- [ ] I have made corresponding changes to the documentation [OPTIONAL]
