### PR TITLE
refactor(migrations): use explicit column name for activity FK

### DIFF
--- a/database/migrations/create_streak_histories_table.php.stub
+++ b/database/migrations/create_streak_histories_table.php.stub
@@ -3,7 +3,6 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
-use LevelUp\Experience\Models\Activity;
 
 return new class extends Migration
 {
@@ -12,7 +11,7 @@ return new class extends Migration
         Schema::create(table: 'streak_histories', callback: function (Blueprint $table) {
             $table->id();
             $table->foreignId(column: config(key: 'level-up.user.foreign_key'))->constrained(table: config(key: 'level-up.user.users_table'))->cascadeOnDelete();
-            $table->foreignIdFor(model: Activity::class)->constrained(table: 'streak_activities');
+            $table->foreignId(column: 'activity_id')->constrained(table: 'streak_activities');
             $table->integer(column: 'count')->default(value: 1);
             $table->timestamp(column: 'started_at');
             $table->timestamp(column: 'ended_at')->nullable();


### PR DESCRIPTION
## Summary

Normalises the activity foreign key in the `create_streak_histories_table` stub to match the package's established `foreignId('column_name')` convention used by every other FK declaration across the 20 migration stubs.

Changes:
- `$table->foreignIdFor(Activity::class)` → `$table->foreignId('activity_id')`
- Removes the now-unused `use LevelUp\Experience\Models\Activity;` import

## Why

This was the only FK declaration in the package's migration stubs using `foreignIdFor(Model::class)` — the other 14 all use the explicit-column form. Standardising on a single style makes the stubs easier to read and audit.

## Backward compatibility

Schema is byte-identical for both new and existing installs:

- `foreignIdFor(Activity::class)` derives the column name as `Str::snake(class_basename(Activity::class)) . '_id'` → `activity_id`
- `Activity` does not override `getForeignKey()`
- Both produce the same `unsignedBigInteger` column with the same name and same chained constraint

Existing installs already ran this migration; their `streak_histories.activity_id` column exists unchanged and Laravel will not re-run it. Fresh installs after this lands produce the same schema as fresh installs today.