### PR TITLE
feat(entities): configurable package entity ID type (bigint/uuid/ulid)

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,13 +15,26 @@ jobs:
         php: [8.3, 8.4, 8.5]
         laravel: ['12.*', '13.*']
         stability: [prefer-stable]
+        key_type: [bigint]
         include:
           - php: 8.3
             laravel: '12.*'
             stability: prefer-lowest
+            key_type: bigint
+          - php: 8.3
+            laravel: '12.*'
+            stability: prefer-stable
+            key_type: uuid
+          - php: 8.3
+            laravel: '12.*'
+            stability: prefer-stable
+            key_type: ulid
 
     name: >
-      PHP: v${{ matrix.php }} [${{ matrix.stability }}]
+      PHP: v${{ matrix.php }} [${{ matrix.stability }}] (id: ${{ matrix.key_type }})
+
+    env:
+      LEVELUP_TEST_KEY_TYPE: ${{ matrix.key_type }}
 
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -48,6 +48,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Package Entities
+    |--------------------------------------------------------------------------
+    |
+    | Set 'id_type' to 'uuid' or 'ulid' if you want package IDs to be opaque.
+    | Only affects fresh installs — see "Customizing Identifiers" below.
+    |
+    */
+    'entities' => [
+        'id_type' => 'bigint',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Experience Table
     |--------------------------------------------------------------------------
     |
@@ -958,6 +971,50 @@ Challenges are enabled by default. To disable:
 ```
 CHALLENGES_ENABLED=false
 ```
+
+# Customizing Identifiers
+
+By default, the package's tables use auto-incrementing `bigint` primary keys. Set `level-up.entities.id_type` to `uuid` or `ulid` if you want package IDs to be opaque — useful when exposing Experience or Achievement records on a public API without leaking row counts.
+
+```php
+'entities' => [
+    'id_type' => 'uuid', // 'bigint' (default) | 'uuid' | 'ulid'
+],
+```
+
+This applies to every package primary key (experiences, levels, achievements, streaks, tiers, multipliers, challenges, and the pivot tables) and every internal foreign key between them. Two columns are intentionally unaffected:
+
+- `user_id` columns — these match whatever your `users` table uses, since they belong to the host application.
+- `multiplier_scopes.scopeable_id` — always a string column, because it polymorphically stores keys from both the host's User table and the package's Tier table.
+
+> [!IMPORTANT]
+> This setting is for **fresh installs**. Existing installs cannot be flipped automatically — column types are baked in at migration time. The accordion below contains an AI prompt that generates the conversion migrations for your specific schema.
+
+<details>
+<summary>AI prompt: convert an existing install to <code>uuid</code> or <code>ulid</code></summary>
+
+Paste this into your AI assistant. Replace `<TARGET>` with `uuid` or `ulid` and `<DB>` with `postgres`, `mysql`, or `sqlite`.
+
+```text
+I'm switching cjmellor/level-up's `entities.id_type` from `bigint` to `<TARGET>` on an existing `<DB>` install.
+
+Generate a Laravel migration (or sequence of migrations) that:
+
+1. For every level-up package table (experiences, levels, achievements, achievement_user, streak_activities, streaks, streak_histories, tiers, multipliers, multiplier_scopes, challenges, challenge_user, experience_audits): add a new `<TARGET>` column called `id_new`, generate a unique value for every existing row, then later drop the old `id` and rename `id_new` to `id`.
+
+2. For every internal foreign key column (`level_id`, `activity_id`, `achievement_id`, `challenge_id`, `tier_id`, `multiplier_id`, etc.): add a corresponding `_new` column, populate it by joining on the parent table's new ids, then drop the old column and rename.
+
+3. Re-establish primary key and foreign key constraints in the correct order. Wrap in a transaction if `<DB>` supports DDL transactions.
+
+Constraints:
+- Do NOT touch `multiplier_scopes.scopeable_id` — that column is intentionally a string and stores morph keys from both User (host-driven) and Tier (package-driven) targets.
+- Do NOT change `user_id` columns in any package table — those follow the host's `users` table type.
+- After the migration runs, update `level-up.entities.id_type` in `config/level-up.php` to `<TARGET>`.
+```
+
+Review the generated migration carefully against your schema and data volume before running it on production.
+
+</details>
 
 # Testing
 

--- a/README.md
+++ b/README.md
@@ -1000,7 +1000,7 @@ I'm switching cjmellor/level-up's `entities.id_type` from `bigint` to `<TARGET>`
 
 Generate a Laravel migration (or sequence of migrations) that:
 
-1. For every level-up package table (experiences, levels, achievements, achievement_user, streak_activities, streaks, streak_histories, tiers, multipliers, multiplier_scopes, challenges, challenge_user, experience_audits): add a new `<TARGET>` column called `id_new`, generate a unique value for every existing row, then later drop the old `id` and rename `id_new` to `id`.
+1. For every level-up package table (experiences, levels, achievements, achievement_user, streak_activities, streaks, streak_histories, tiers, multipliers, multiplier_scopes, challenges, challenge_user, experience_audits): add a new `<TARGET>` column called `id_new`, generate a unique value for every existing row, then later drop the old `id` and rename `id_new` to `id`. For `multiplier_scopes`, this applies only to the `id` primary key — do NOT touch `scopeable_id` (see Constraints below).
 
 2. For every internal foreign key column (`level_id`, `activity_id`, `achievement_id`, `challenge_id`, `tier_id`, `multiplier_id`, etc.): add a corresponding `_new` column, populate it by joining on the parent table's new ids, then drop the old column and rename.
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -178,6 +178,12 @@ class User extends Model
 
 **To disable challenges entirely**, set `CHALLENGES_ENABLED=false` in your `.env` file.
 
+### New: Configurable Entity ID Type
+
+**Likelihood of Impact: Low**
+
+The package's own primary keys can now be configured as `uuid` or `ulid` via `level-up.entities.id_type` (default remains `bigint`). Existing installs are unaffected on `composer update` — the setting only changes how *new* migrations build their tables. See the [Customizing Identifiers section in the README](README.md#customizing-identifiers) for the conversion path if you want to migrate an existing install.
+
 ### Bug Fixes Included
 
 - `levelUp()` now correctly fires `UserLevelledUp` events for all intermediate levels (previously only fired for the final level)

--- a/config/level-up.php
+++ b/config/level-up.php
@@ -36,6 +36,25 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Package Entities
+    |--------------------------------------------------------------------------
+    |
+    | 'id_type' controls the primary key column type used for the package's
+    | own tables (experiences, levels, achievements, etc.) and every internal
+    | foreign key between them. Set to 'uuid' or 'ulid' if you want package
+    | IDs to be opaque (e.g., for safe exposure on a public API surface).
+    | Leave as 'bigint' for standard auto-increment IDs. Only affects fresh
+    | migrations; existing installs keep whichever column type they already
+    | migrated with. See the README "Customizing Identifiers" section for
+    | guidance on switching an existing install.
+    |
+    */
+    'entities' => [
+        'id_type' => 'bigint',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Experience Table
     |--------------------------------------------------------------------------
     |

--- a/database/migrations/add_level_relationship_to_users_table.php.stub
+++ b/database/migrations/add_level_relationship_to_users_table.php.stub
@@ -8,7 +8,7 @@ return new class extends Migration {
     public function up(): void
     {
         Schema::table(config('level-up.user.users_table'), function (Blueprint $table) {
-            $table->foreignId('level_id')
+            $table->entityForeignId('level_id')
                 ->after('remember_token')
                 ->nullable()
                 ->constrained();

--- a/database/migrations/add_tier_id_to_achievements_table.php.stub
+++ b/database/migrations/add_tier_id_to_achievements_table.php.stub
@@ -8,7 +8,7 @@ return new class extends Migration {
     public function up(): void
     {
         Schema::table('achievements', function (Blueprint $table) {
-            $table->foreignId('tier_id')->nullable()->constrained('tiers')->nullOnDelete();
+            $table->entityForeignId('tier_id')->nullable()->constrained('tiers')->nullOnDelete();
         });
     }
 

--- a/database/migrations/add_tier_id_to_experiences_table.php.stub
+++ b/database/migrations/add_tier_id_to_experiences_table.php.stub
@@ -8,7 +8,7 @@ return new class extends Migration {
     public function up(): void
     {
         Schema::table(config('level-up.table'), function (Blueprint $table) {
-            $table->foreignId('tier_id')->nullable()->constrained('tiers')->nullOnDelete();
+            $table->entityForeignId('tier_id')->nullable()->constrained('tiers')->nullOnDelete();
         });
     }
 

--- a/database/migrations/create_achievement_user_pivot_table.php.stub
+++ b/database/migrations/create_achievement_user_pivot_table.php.stub
@@ -8,9 +8,9 @@ return new class extends Migration {
     public function up(): void
     {
         Schema::create('achievement_user', function (Blueprint $table) {
-            $table->id();
+            $table->entityId();
             $table->foreignId(column: config('level-up.user.foreign_key'))->constrained(config('level-up.user.users_table'));
-            $table->foreignId(column: 'achievement_id')->constrained();
+            $table->entityForeignId(column: 'achievement_id')->constrained();
             $table->integer(column: 'progress')->nullable()->index();
             $table->timestamps();
         });

--- a/database/migrations/create_achievements_table.php.stub
+++ b/database/migrations/create_achievements_table.php.stub
@@ -8,7 +8,7 @@ return new class extends Migration {
     public function up(): void
     {
         Schema::create('achievements', function (Blueprint $table) {
-            $table->id();
+            $table->entityId();
             $table->string('name');
             $table->boolean('is_secret')->default(false);
             $table->text('description')->nullable();

--- a/database/migrations/create_challenge_user_table.php.stub
+++ b/database/migrations/create_challenge_user_table.php.stub
@@ -8,9 +8,9 @@ return new class extends Migration {
     public function up(): void
     {
         Schema::create('challenge_user', function (Blueprint $table) {
-            $table->id();
+            $table->entityId();
             $table->foreignId(column: config('level-up.user.foreign_key'))->constrained(config('level-up.user.users_table'));
-            $table->foreignId(column: 'challenge_id')->constrained();
+            $table->entityForeignId(column: 'challenge_id')->constrained();
             $table->json(column: 'progress')->nullable();
             $table->timestamp(column: 'completed_at')->nullable();
             $table->timestamps();

--- a/database/migrations/create_challenges_table.php.stub
+++ b/database/migrations/create_challenges_table.php.stub
@@ -8,7 +8,7 @@ return new class extends Migration {
     public function up(): void
     {
         Schema::create('challenges', function (Blueprint $table) {
-            $table->id();
+            $table->entityId();
             $table->string(column: 'name');
             $table->text(column: 'description')->nullable();
             $table->string(column: 'image')->nullable();

--- a/database/migrations/create_experience_audits_table.php.stub
+++ b/database/migrations/create_experience_audits_table.php.stub
@@ -8,7 +8,7 @@ return new class extends Migration {
     public function up(): void
     {
         Schema::create('experience_audits', function (Blueprint $table) {
-            $table->id();
+            $table->entityId();
             $table->foreignId(config('level-up.user.foreign_key'))->constrained(config('level-up.user.users_table'));
             $table->integer('points')->index();
             $table->boolean('levelled_up')->default(false);

--- a/database/migrations/create_experiences_table.php.stub
+++ b/database/migrations/create_experiences_table.php.stub
@@ -9,9 +9,9 @@ return new class extends Migration
     public function up()
     {
         Schema::create(config('level-up.table'), function (Blueprint $table) {
-            $table->id();
+            $table->entityId();
             $table->foreignId(config('level-up.user.foreign_key'))->constrained(config('level-up.user.users_table'));
-            $table->foreignId('level_id')->constrained();
+            $table->entityForeignId('level_id')->constrained();
             $table->integer('experience_points')->default(0)->index();
             $table->timestamps();
         });

--- a/database/migrations/create_levels_table.php.stub
+++ b/database/migrations/create_levels_table.php.stub
@@ -9,7 +9,7 @@ return new class extends Migration
     public function up()
     {
         Schema::create('levels', function (Blueprint $table) {
-            $table->id();
+            $table->entityId();
             $table->integer('level')->unique();
             $table->integer('next_level_experience')->nullable()->index();
             $table->timestamps();

--- a/database/migrations/create_multiplier_scopes_table.php.stub
+++ b/database/migrations/create_multiplier_scopes_table.php.stub
@@ -8,10 +8,10 @@ return new class extends Migration {
     public function up(): void
     {
         Schema::create('multiplier_scopes', function (Blueprint $table) {
-            $table->id();
-            $table->foreignId('multiplier_id')->constrained()->cascadeOnDelete();
+            $table->entityId();
+            $table->entityForeignId('multiplier_id')->constrained()->cascadeOnDelete();
             $table->string('scopeable_type');
-            $table->unsignedBigInteger('scopeable_id');
+            $table->string('scopeable_id');
             $table->timestamps();
 
             $table->unique(['multiplier_id', 'scopeable_type', 'scopeable_id'], 'multiplier_scopes_unique');

--- a/database/migrations/create_multipliers_table.php.stub
+++ b/database/migrations/create_multipliers_table.php.stub
@@ -8,7 +8,7 @@ return new class extends Migration {
     public function up(): void
     {
         Schema::create('multipliers', function (Blueprint $table) {
-            $table->id();
+            $table->entityId();
             $table->string('name');
             $table->text('description')->nullable();
             $table->decimal('multiplier', 8, 2);

--- a/database/migrations/create_streak_activities_table.php.stub
+++ b/database/migrations/create_streak_activities_table.php.stub
@@ -8,7 +8,7 @@ return new class extends Migration {
     public function up(): void
     {
         Schema::create('streak_activities', function (Blueprint $table) {
-            $table->id();
+            $table->entityId();
             $table->string('name')->unique();
             $table->text('description')->nullable();
             $table->timestamps();

--- a/database/migrations/create_streak_histories_table.php.stub
+++ b/database/migrations/create_streak_histories_table.php.stub
@@ -9,9 +9,9 @@ return new class extends Migration
     public function up(): void
     {
         Schema::create(table: 'streak_histories', callback: function (Blueprint $table) {
-            $table->id();
+            $table->entityId();
             $table->foreignId(column: config(key: 'level-up.user.foreign_key'))->constrained(table: config(key: 'level-up.user.users_table'))->cascadeOnDelete();
-            $table->foreignId(column: 'activity_id')->constrained(table: 'streak_activities');
+            $table->entityForeignId(column: 'activity_id')->constrained(table: 'streak_activities');
             $table->integer(column: 'count')->default(value: 1);
             $table->timestamp(column: 'started_at');
             $table->timestamp(column: 'ended_at')->nullable();

--- a/database/migrations/create_streaks_table.php.stub
+++ b/database/migrations/create_streaks_table.php.stub
@@ -8,9 +8,9 @@ return new class extends Migration {
     public function up(): void
     {
         Schema::create('streaks', function (Blueprint $table) {
-            $table->id();
+            $table->entityId();
             $table->foreignId(column: config('level-up.user.foreign_key'))->constrained()->onDelete('cascade');
-            $table->foreignId(column: 'activity_id')->constrained('streak_activities')->onDelete('cascade');
+            $table->entityForeignId(column: 'activity_id')->constrained('streak_activities')->onDelete('cascade');
             $table->integer(column: 'count')->default(1);
             $table->timestamp(column: 'activity_at');
             $table->timestamps();

--- a/database/migrations/create_tiers_table.php.stub
+++ b/database/migrations/create_tiers_table.php.stub
@@ -8,7 +8,7 @@ return new class extends Migration {
     public function up(): void
     {
         Schema::create('tiers', function (Blueprint $table) {
-            $table->id();
+            $table->entityId();
             $table->string('name')->unique();
             $table->unsignedBigInteger('experience')->unique();
             $table->json('metadata')->nullable();

--- a/database/migrations/remove_level_id_column_from_users_table.php.stub
+++ b/database/migrations/remove_level_id_column_from_users_table.php.stub
@@ -15,7 +15,7 @@ return new class extends Migration {
     public function down(): void
     {
         Schema::table(config('level-up.user.users_table'), function (Blueprint $table) {
-            $table->foreignId('level_id')->nullable()->constrained();
+            $table->entityForeignId('level_id')->nullable()->constrained();
         });
     }
 };

--- a/resources/boost/skills/level-up-upgrade-v2/SKILL.md
+++ b/resources/boost/skills/level-up-upgrade-v2/SKILL.md
@@ -252,4 +252,18 @@ Review every match and ensure the corresponding fix from Step 5 has been applied
    - `TypeError` from strict types — cast parameters to correct types
    - `Exception` from `incrementAchievementProgress()` — grant the achievement first
 3. Re-run tests until green.
-4. Inform the user: "Upgrade to v2 complete. All breaking changes have been applied."
+
+## Step 9: Optionally switch entity ID type
+
+v2 introduces `level-up.entities.id_type` (default `bigint`) which controls the primary-key column type for the package's own tables. The other supported values are `uuid` and `ulid`.
+
+Ask the user:
+
+> "Would you like to switch the package's entity IDs to `uuid` or `ulid`? This is useful if you plan to expose Experience, Achievement, etc. records on a public API and don't want sequential IDs to leak row counts. It requires a one-time data migration."
+
+- If **No**: continue without changes. The default `bigint` is identical to v1 behaviour and needs no action.
+- If **Yes**: **do not attempt the conversion in this skill.** Point the user at the [Customizing Identifiers section in the README](../../../../README.md#customizing-identifiers). That section contains an AI prompt the user can paste into a fresh assistant session to generate conversion migrations tailored to their schema and database driver. The conversion is intentionally out of scope here because it depends on data volume, downtime tolerance, and DB driver specifics that this skill has no visibility into.
+
+## Step 10: Finish
+
+Inform the user: "Upgrade to v2 complete. All breaking changes have been applied."

--- a/src/Concerns/HasConfigurableIds.php
+++ b/src/Concerns/HasConfigurableIds.php
@@ -6,6 +6,7 @@ namespace LevelUp\Experience\Concerns;
 
 use Illuminate\Database\Eloquent\Concerns\HasUniqueIds;
 use Illuminate\Support\Str;
+use InvalidArgumentException;
 
 trait HasConfigurableIds
 {
@@ -13,7 +14,7 @@ trait HasConfigurableIds
 
     public function initializeHasConfigurableIds(): void
     {
-        $this->usesUniqueIds = $this->packageIdType() !== 'bigint';
+        $this->usesUniqueIds = in_array($this->packageIdType(), ['uuid', 'ulid'], true);
     }
 
     public function getKeyType(): string
@@ -28,10 +29,14 @@ trait HasConfigurableIds
 
     public function newUniqueId(): string
     {
-        return match ($this->packageIdType()) {
+        $type = $this->packageIdType();
+
+        return match ($type) {
             'ulid' => strtolower((string) Str::ulid()),
             'uuid' => (string) Str::uuid(),
-            default => '',
+            default => throw new InvalidArgumentException(
+                "Unknown level-up.entities.id_type [{$type}]. Expected 'bigint', 'uuid', or 'ulid'."
+            ),
         };
     }
 

--- a/src/Concerns/HasConfigurableIds.php
+++ b/src/Concerns/HasConfigurableIds.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LevelUp\Experience\Concerns;
+
+use Illuminate\Database\Eloquent\Concerns\HasUniqueIds;
+use Illuminate\Support\Str;
+
+trait HasConfigurableIds
+{
+    use HasUniqueIds;
+
+    public function getKeyType(): string
+    {
+        return $this->packageIdType() === 'bigint' ? 'int' : 'string';
+    }
+
+    public function getIncrementing(): bool
+    {
+        return $this->packageIdType() === 'bigint';
+    }
+
+    public function newUniqueId(): string
+    {
+        return match ($this->packageIdType()) {
+            'ulid' => strtolower((string) Str::ulid()),
+            'uuid' => (string) Str::uuid(),
+            default => '',
+        };
+    }
+
+    public function uniqueIds(): array
+    {
+        return $this->packageIdType() === 'bigint'
+            ? []
+            : [$this->getKeyName()];
+    }
+
+    protected function packageIdType(): string
+    {
+        return config('level-up.entities.id_type', 'bigint');
+    }
+}

--- a/src/Concerns/HasConfigurableIds.php
+++ b/src/Concerns/HasConfigurableIds.php
@@ -11,6 +11,11 @@ trait HasConfigurableIds
 {
     use HasUniqueIds;
 
+    public function initializeHasConfigurableIds(): void
+    {
+        $this->usesUniqueIds = $this->packageIdType() !== 'bigint';
+    }
+
     public function getKeyType(): string
     {
         return $this->packageIdType() === 'bigint' ? 'int' : 'string';

--- a/src/LevelUpServiceProvider.php
+++ b/src/LevelUpServiceProvider.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace LevelUp\Experience;
 
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Schema\ForeignIdColumnDefinition;
+use InvalidArgumentException;
 use LevelUp\Experience\Providers\EventServiceProvider;
 use LevelUp\Experience\Services\LeaderboardService;
 use Spatie\LaravelPackageTools\Package;
@@ -11,6 +14,11 @@ use Spatie\LaravelPackageTools\PackageServiceProvider;
 
 class LevelUpServiceProvider extends PackageServiceProvider
 {
+    public function bootingPackage(): void
+    {
+        $this->registerEntityKeyMacros();
+    }
+
     public function configurePackage(Package $package): void
     {
         $package
@@ -46,5 +54,36 @@ class LevelUpServiceProvider extends PackageServiceProvider
 
         $this->app->register(provider: EventServiceProvider::class);
         $this->app->singleton(abstract: 'leaderboard', concrete: fn (): LeaderboardService => new LeaderboardService());
+    }
+
+    protected function registerEntityKeyMacros(): void
+    {
+        if (! Blueprint::hasMacro('entityId')) {
+            Blueprint::macro('entityId', function (string $column = 'id'): void {
+                /** @var Blueprint $this */
+                match (config('level-up.entities.id_type', 'bigint')) {
+                    'bigint' => $this->id($column),
+                    'uuid' => $this->uuid($column)->primary(),
+                    'ulid' => $this->ulid($column)->primary(),
+                    default => throw new InvalidArgumentException(
+                        'Unknown level-up.entities.id_type ['.config('level-up.entities.id_type')."]. Expected 'bigint', 'uuid', or 'ulid'."
+                    ),
+                };
+            });
+        }
+
+        if (! Blueprint::hasMacro('entityForeignId')) {
+            Blueprint::macro('entityForeignId', function (string $column): ForeignIdColumnDefinition {
+                /** @var Blueprint $this */
+                return match (config('level-up.entities.id_type', 'bigint')) {
+                    'bigint' => $this->foreignId($column),
+                    'uuid' => $this->foreignUuid($column),
+                    'ulid' => $this->foreignUlid($column),
+                    default => throw new InvalidArgumentException(
+                        'Unknown level-up.entities.id_type ['.config('level-up.entities.id_type')."]. Expected 'bigint', 'uuid', or 'ulid'."
+                    ),
+                };
+            });
+        }
     }
 }

--- a/src/LevelUpServiceProvider.php
+++ b/src/LevelUpServiceProvider.php
@@ -58,30 +58,35 @@ class LevelUpServiceProvider extends PackageServiceProvider
 
     protected function registerEntityKeyMacros(): void
     {
+        $resolveIdType = static function (): string {
+            $idType = config('level-up.entities.id_type', 'bigint');
+
+            return match ($idType) {
+                'bigint', 'uuid', 'ulid' => $idType,
+                default => throw new InvalidArgumentException(
+                    "Unknown level-up.entities.id_type [{$idType}]. Expected 'bigint', 'uuid', or 'ulid'."
+                ),
+            };
+        };
+
         if (! Blueprint::hasMacro('entityId')) {
-            Blueprint::macro('entityId', function (string $column = 'id'): void {
+            Blueprint::macro('entityId', function (string $column = 'id') use ($resolveIdType): void {
                 /** @var Blueprint $this */
-                match (config('level-up.entities.id_type', 'bigint')) {
+                match ($resolveIdType()) {
                     'bigint' => $this->id($column),
                     'uuid' => $this->uuid($column)->primary(),
                     'ulid' => $this->ulid($column)->primary(),
-                    default => throw new InvalidArgumentException(
-                        'Unknown level-up.entities.id_type ['.config('level-up.entities.id_type')."]. Expected 'bigint', 'uuid', or 'ulid'."
-                    ),
                 };
             });
         }
 
         if (! Blueprint::hasMacro('entityForeignId')) {
-            Blueprint::macro('entityForeignId', function (string $column): ForeignIdColumnDefinition {
+            Blueprint::macro('entityForeignId', function (string $column) use ($resolveIdType): ForeignIdColumnDefinition {
                 /** @var Blueprint $this */
-                return match (config('level-up.entities.id_type', 'bigint')) {
+                return match ($resolveIdType()) {
                     'bigint' => $this->foreignId($column),
                     'uuid' => $this->foreignUuid($column),
                     'ulid' => $this->foreignUlid($column),
-                    default => throw new InvalidArgumentException(
-                        'Unknown level-up.entities.id_type ['.config('level-up.entities.id_type')."]. Expected 'bigint', 'uuid', or 'ulid'."
-                    ),
                 };
             });
         }

--- a/src/Models/Achievement.php
+++ b/src/Models/Achievement.php
@@ -8,10 +8,11 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use LevelUp\Experience\Concerns\HasConfigurableIds;
 
 class Achievement extends Model
 {
-    use HasFactory;
+    use HasConfigurableIds, HasFactory;
 
     protected $guarded = [];
 

--- a/src/Models/Activity.php
+++ b/src/Models/Activity.php
@@ -7,10 +7,11 @@ namespace LevelUp\Experience\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use LevelUp\Experience\Concerns\HasConfigurableIds;
 
 class Activity extends Model
 {
-    use HasFactory;
+    use HasConfigurableIds, HasFactory;
 
     protected $table = 'streak_activities';
 

--- a/src/Models/Challenge.php
+++ b/src/Models/Challenge.php
@@ -10,11 +10,12 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use InvalidArgumentException;
+use LevelUp\Experience\Concerns\HasConfigurableIds;
 use LevelUp\Experience\Contracts\ChallengeCondition;
 
 class Challenge extends Model
 {
-    use HasFactory;
+    use HasConfigurableIds, HasFactory;
 
     protected $guarded = [];
 

--- a/src/Models/Experience.php
+++ b/src/Models/Experience.php
@@ -6,9 +6,12 @@ namespace LevelUp\Experience\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use LevelUp\Experience\Concerns\HasConfigurableIds;
 
 class Experience extends Model
 {
+    use HasConfigurableIds;
+
     protected $guarded = [];
 
     public function __construct(array $attributes = [])

--- a/src/Models/ExperienceAudit.php
+++ b/src/Models/ExperienceAudit.php
@@ -6,10 +6,13 @@ namespace LevelUp\Experience\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use LevelUp\Experience\Concerns\HasConfigurableIds;
 use LevelUp\Experience\Enums\AuditType;
 
 class ExperienceAudit extends Model
 {
+    use HasConfigurableIds;
+
     protected $guarded = [];
 
     protected $casts = [

--- a/src/Models/Level.php
+++ b/src/Models/Level.php
@@ -7,10 +7,13 @@ namespace LevelUp\Experience\Models;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\UniqueConstraintViolationException;
+use LevelUp\Experience\Concerns\HasConfigurableIds;
 use LevelUp\Experience\Exceptions\LevelExistsException;
 
 class Level extends Model
 {
+    use HasConfigurableIds;
+
     protected $guarded = [];
 
     /**

--- a/src/Models/Multiplier.php
+++ b/src/Models/Multiplier.php
@@ -10,9 +10,12 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use InvalidArgumentException;
+use LevelUp\Experience\Concerns\HasConfigurableIds;
 
 class Multiplier extends Model
 {
+    use HasConfigurableIds;
+
     protected $guarded = [];
 
     protected $casts = [
@@ -42,7 +45,7 @@ class Multiplier extends Model
         foreach ($models as $model) {
             $this->scopes()->firstOrCreate([
                 'scopeable_type' => $model->getMorphClass(),
-                'scopeable_id' => $model->getKey(),
+                'scopeable_id' => (string) $model->getKey(),
             ]);
         }
 
@@ -95,12 +98,12 @@ class Multiplier extends Model
                 ->where(fn (Builder $match) => $match
                     ->where([
                         'scopeable_type' => $user->getMorphClass(),
-                        'scopeable_id' => $user->getKey(),
+                        'scopeable_id' => (string) $user->getKey(),
                     ])
                     ->when($tierId, fn (Builder $tierMatch) => $tierMatch
                         ->orWhere([
                             'scopeable_type' => (new $tierClass)->getMorphClass(),
-                            'scopeable_id' => $tierId,
+                            'scopeable_id' => (string) $tierId,
                         ])
                     )
                 )

--- a/src/Models/MultiplierScope.php
+++ b/src/Models/MultiplierScope.php
@@ -7,9 +7,12 @@ namespace LevelUp\Experience\Models;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
+use LevelUp\Experience\Concerns\HasConfigurableIds;
 
 class MultiplierScope extends Model
 {
+    use HasConfigurableIds;
+
     protected $guarded = [];
 
     public function multiplier(): BelongsTo

--- a/src/Models/Pivots/AchievementUser.php
+++ b/src/Models/Pivots/AchievementUser.php
@@ -5,5 +5,9 @@ declare(strict_types=1);
 namespace LevelUp\Experience\Models\Pivots;
 
 use Illuminate\Database\Eloquent\Relations\Pivot;
+use LevelUp\Experience\Concerns\HasConfigurableIds;
 
-class AchievementUser extends Pivot {}
+class AchievementUser extends Pivot
+{
+    use HasConfigurableIds;
+}

--- a/src/Models/Pivots/ChallengeUser.php
+++ b/src/Models/Pivots/ChallengeUser.php
@@ -5,9 +5,12 @@ declare(strict_types=1);
 namespace LevelUp\Experience\Models\Pivots;
 
 use Illuminate\Database\Eloquent\Relations\Pivot;
+use LevelUp\Experience\Concerns\HasConfigurableIds;
 
 class ChallengeUser extends Pivot
 {
+    use HasConfigurableIds;
+
     protected $casts = [
         'completed_at' => 'datetime',
         'progress' => 'array',

--- a/src/Models/Streak.php
+++ b/src/Models/Streak.php
@@ -7,10 +7,11 @@ namespace LevelUp\Experience\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use LevelUp\Experience\Concerns\HasConfigurableIds;
 
 class Streak extends Model
 {
-    use HasFactory;
+    use HasConfigurableIds, HasFactory;
 
     protected $guarded = [];
 

--- a/src/Models/StreakHistory.php
+++ b/src/Models/StreakHistory.php
@@ -5,9 +5,12 @@ declare(strict_types=1);
 namespace LevelUp\Experience\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use LevelUp\Experience\Concerns\HasConfigurableIds;
 
 class StreakHistory extends Model
 {
+    use HasConfigurableIds;
+
     protected $guarded = [];
 
     protected $casts = [

--- a/src/Models/Tier.php
+++ b/src/Models/Tier.php
@@ -8,11 +8,12 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\UniqueConstraintViolationException;
 use Illuminate\Support\Facades\DB;
+use LevelUp\Experience\Concerns\HasConfigurableIds;
 use LevelUp\Experience\Exceptions\TierExistsException;
 
 class Tier extends Model
 {
-    use HasFactory;
+    use HasConfigurableIds, HasFactory;
 
     protected $guarded = [];
 

--- a/tests/Concerns/GiveExperienceTest.php
+++ b/tests/Concerns/GiveExperienceTest.php
@@ -26,7 +26,7 @@ test(description: 'giving points to a User without an experience Model, creates 
 
     $this->assertDatabaseHas(table: 'experiences', data: [
         'user_id' => $this->user->id,
-        'level_id' => 1,
+        'level_id' => $this->levels[1]->id,
         'experience_points' => 10,
     ]);
 });
@@ -45,7 +45,7 @@ test(description: 'giving points to a User with an experience Model, updates the
 
     $this->assertDatabaseHas(table: 'experiences', data: [
         'user_id' => $this->user->id,
-        'level_id' => 1,
+        'level_id' => $this->levels[1]->id,
         'experience_points' => 20,
     ]);
 });
@@ -53,7 +53,7 @@ test(description: 'giving points to a User with an experience Model, updates the
 test(description: 'levels are associated on point increments', closure: function (): void {
     $this->user->addPoints(amount: 10);
 
-    expect($this->user->experience)->level_id->toBe(expected: 1);
+    expect($this->user->experience->level_id)->toBe($this->levels[1]->id);
 
     $this->user->addPoints(amount: 100);
 
@@ -75,7 +75,7 @@ it(description: 'can deduct points from a User', closure: function (): void {
 
     $this->assertDatabaseHas(table: 'experiences', data: [
         'user_id' => $this->user->id,
-        'level_id' => 1,
+        'level_id' => $this->levels[1]->id,
         'experience_points' => 5,
     ]);
 });
@@ -91,7 +91,7 @@ it(description: 'can set points to a User', closure: function (): void {
 
     $this->assertDatabaseHas(table: 'experiences', data: [
         'user_id' => $this->user->id,
-        'level_id' => 1,
+        'level_id' => $this->levels[1]->id,
         'experience_points' => 5,
     ]);
 });
@@ -117,7 +117,7 @@ test(description: 'when using a multiplier, times the points by it', closure: fu
 
     $this->assertDatabaseHas(table: 'experiences', data: [
         'user_id' => $this->user->id,
-        'level_id' => 1,
+        'level_id' => $this->levels[1]->id,
         'experience_points' => 20,
     ]);
 });
@@ -139,7 +139,7 @@ test(description: 'DB multipliers are applied automatically when active', closur
 
     $this->assertDatabaseHas(table: 'experiences', data: [
         'user_id' => $this->user->id,
-        'level_id' => 1,
+        'level_id' => $this->levels[1]->id,
         'experience_points' => 20,
     ]);
 });
@@ -420,7 +420,6 @@ test(description: 'Add default level if not applied before trying to add points'
     expect(Level::query()->count())->toBe(expected: 1);
 
     $this->assertDatabaseHas(table: 'levels', data: [
-        'id' => 1,
         'level' => 1,
         'next_level_experience' => null,
     ]);
@@ -432,7 +431,7 @@ it(description: 'throws an error when points added exceed the last levels experi
 
 test(description: 'the level is correct when adding more points than available on initial experience gain', closure: function (): void {
     $this->user->addPoints(amount: 10);
-    expect($this->user->experience)->level_id->toBe(expected: 1);
+    expect($this->user->experience->level_id)->toBe($this->levels[1]->id);
     $this->user->setPoints(amount: 0);
 
     $this->user->addPoints(100);

--- a/tests/Listeners/PointsIncreasedListenerTest.php
+++ b/tests/Listeners/PointsIncreasedListenerTest.php
@@ -26,11 +26,11 @@ test(description: 'the Event and Listener run when points are added to a User Mo
 test(description: 'the level_id in Experience table defaults to 1 on Model creation', closure: function (): void {
     $this->user->addPoints(1);
 
-    expect($this->user->experience->level_id)->toBe(expected: 1);
+    expect($this->user->experience->level_id)->toBe($this->levels[1]->id);
 
     $this->assertDatabaseHas(table: 'experiences', data: [
         'user_id' => $this->user->id,
-        'level_id' => 1,
+        'level_id' => $this->levels[1]->id,
     ]);
 });
 
@@ -74,14 +74,14 @@ test(description: 'user levels are correct', closure: function (): void {
     $this->user->addPoints(amount: 100);
 
     expect($this->user->getLevel())->toBe(expected: 2)
-        ->and($this->user->experience->level_id)->toBe(expected: 2)
+        ->and($this->user->experience->level_id)->toBe($this->levels[2]->id)
         ->and($this->user->nextLevelAt())->toBe(expected: 150)
         ->and($this->user->experience->status->level)->toBe(expected: 2);
 
     $this->assertDatabaseHas(table: 'experiences', data: [
         'user_id' => $this->user->id,
         'experience_points' => 100,
-        'level_id' => 2,
+        'level_id' => $this->levels[2]->id,
     ]);
 
     $this->user->addPoints(amount: 150);
@@ -92,7 +92,7 @@ test(description: 'user levels are correct', closure: function (): void {
 
     $this->assertDatabaseHas(table: 'experiences', data: [
         'user_id' => $this->user->id,
-        'level_id' => 3,
+        'level_id' => $this->levels[3]->id,
     ]);
 });
 

--- a/tests/Listeners/UserLevelledUpListenerTest.php
+++ b/tests/Listeners/UserLevelledUpListenerTest.php
@@ -39,7 +39,7 @@ test(description: 'when a User levels up more than once, an event runs for each 
 
     $this->user->addPoints(300);
 
-    expect($this->user)->experience->level_id->toBe(expected: 3);
+    expect($this->user)->experience->level_id->toBe($this->levels[3]->id);
 
     Event::assertDispatchedTimes(event: UserLevelledUp::class, times: 3);
 

--- a/tests/Models/MultiplierTest.php
+++ b/tests/Models/MultiplierTest.php
@@ -166,7 +166,7 @@ test(description: 'scopeTo creates scopes for given models', closure: function (
 
     expect($multiplier->scopes)->toHaveCount(1)
         ->and($multiplier->scopes->first()->scopeable_type)->toBe(User::class)
-        ->and($multiplier->scopes->first()->scopeable_id)->toBe($this->user->id);
+        ->and($multiplier->scopes->first()->scopeable_id)->toBe((string) $this->user->id);
 });
 
 test(description: 'scopeTo is idempotent for the same model', closure: function (): void {

--- a/tests/Models/MultiplierTest.php
+++ b/tests/Models/MultiplierTest.php
@@ -70,7 +70,7 @@ test(description: 'forUser scope filters by user scope', closure: function (): v
 
     $multiplier->scopes()->create([
         'scopeable_type' => User::class,
-        'scopeable_id' => $this->user->id,
+        'scopeable_id' => (string) $this->user->id,
     ]);
 
     $otherUser = User::query()->create(['name' => 'Other', 'email' => 'other@test.com', 'password' => bcrypt(value: 'password')]);
@@ -90,7 +90,7 @@ test(description: 'forUser scope filters by tier scope', closure: function (): v
     $multiplier = Multiplier::query()->create(['name' => 'Silver Bonus', 'multiplier' => 2, 'is_active' => true]);
     $multiplier->scopes()->create([
         'scopeable_type' => Tier::class,
-        'scopeable_id' => $silverTier->id,
+        'scopeable_id' => (string) $silverTier->id,
     ]);
 
     $this->user->addPoints(amount: 10);
@@ -124,8 +124,8 @@ test(description: 'multiplier has many scopes relationship', closure: function (
     $multiplier = Multiplier::query()->create(['name' => 'Scoped', 'multiplier' => 2, 'is_active' => true]);
 
     $multiplier->scopes()->createMany([
-        ['scopeable_type' => User::class, 'scopeable_id' => 1],
-        ['scopeable_type' => Tier::class, 'scopeable_id' => 1],
+        ['scopeable_type' => User::class, 'scopeable_id' => '1'],
+        ['scopeable_type' => Tier::class, 'scopeable_id' => '1'],
     ]);
 
     expect($multiplier->scopes)->toHaveCount(2);
@@ -133,7 +133,7 @@ test(description: 'multiplier has many scopes relationship', closure: function (
 
 test(description: 'multiplier scopes are associated correctly', closure: function (): void {
     $multiplier = Multiplier::query()->create(['name' => 'Scoped', 'multiplier' => 2, 'is_active' => true]);
-    $multiplier->scopes()->create(['scopeable_type' => User::class, 'scopeable_id' => 1]);
+    $multiplier->scopes()->create(['scopeable_type' => User::class, 'scopeable_id' => '1']);
 
     expect(MultiplierScope::query()->count())->toBe(1)
         ->and(MultiplierScope::query()->first()->multiplier_id)->toBe($multiplier->id);
@@ -186,7 +186,7 @@ test(description: 'multiplier scoped to both user and tier is only applied once'
 
     $multiplier = Multiplier::query()->create(['name' => 'Dual Scoped', 'multiplier' => 3, 'is_active' => true]);
     $multiplier->scopeTo($this->user);
-    $multiplier->scopes()->create(['scopeable_type' => Tier::class, 'scopeable_id' => $tier->id]);
+    $multiplier->scopes()->create(['scopeable_type' => Tier::class, 'scopeable_id' => (string) $tier->id]);
 
     $this->user->addPoints(amount: 10);
     $this->user->experience->update(['tier_id' => $tier->id]);
@@ -200,7 +200,7 @@ test(description: 'multiplier scoped to both user and tier is only applied once'
 test(description: 'tiers relationship returns morphed tiers', closure: function (): void {
     $tier = Tier::query()->create(['name' => 'Gold', 'experience' => 500]);
     $multiplier = Multiplier::query()->create(['name' => 'Tier Bonus', 'multiplier' => 3, 'is_active' => true]);
-    $multiplier->scopes()->create(['scopeable_type' => Tier::class, 'scopeable_id' => $tier->id]);
+    $multiplier->scopes()->create(['scopeable_type' => Tier::class, 'scopeable_id' => (string) $tier->id]);
 
     expect($multiplier->tiers)->toHaveCount(1)
         ->and($multiplier->tiers->first()->name)->toBe('Gold');
@@ -210,7 +210,7 @@ test(description: 'users relationship returns morphed users', closure: function 
     config()->set('level-up.user.model', User::class);
 
     $multiplier = Multiplier::query()->create(['name' => 'User Bonus', 'multiplier' => 2, 'is_active' => true]);
-    $multiplier->scopes()->create(['scopeable_type' => User::class, 'scopeable_id' => $this->user->id]);
+    $multiplier->scopes()->create(['scopeable_type' => User::class, 'scopeable_id' => (string) $this->user->id]);
 
     expect($multiplier->users)->toHaveCount(1)
         ->and($multiplier->users->first()->id)->toBe($this->user->id);

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -18,13 +18,15 @@ uses(TestCase::class, RefreshDatabase::class)
             'email_verified_at' => now(),
         ])->save();
 
-        Level::add(
+        $levels = Level::add(
             ['level' => 1, 'next_level_experience' => null],
             ['level' => 2, 'next_level_experience' => 100],
             ['level' => 3, 'next_level_experience' => 250],
             ['level' => 4, 'next_level_experience' => 400],
             ['level' => 5, 'next_level_experience' => 600],
         );
+
+        $this->levels = collect($levels)->keyBy('level');
     })
     ->in(__DIR__);
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -34,6 +34,7 @@ class TestCase extends Orchestra
     {
         config()->set('database.default', 'testing');
         config()->set('level-up.user.model', \LevelUp\Experience\Tests\Fixtures\User::class);
+        config()->set('level-up.entities.id_type', env('LEVELUP_TEST_KEY_TYPE', 'bigint'));
 
         Schema::create('users', function ($table): void {
             $table->id();


### PR DESCRIPTION
## Summary

Resolves the (b) half of christoph-kluge's UUID/ULID feedback on #124. Lets host apps choose how the package's own primary keys are stored: `bigint` (default), `uuid`, or `ulid`. Useful when you want to expose Experience or Achievement records on a public API without sequential IDs leaking row counts.

- New config key `level-up.entities.id_type` (default `'bigint'`, accepts `'uuid'` / `'ulid'`)
- New Blueprint macros `$table->entityId()` and `$table->entityForeignId('xxx_id')`, registered in `LevelUpServiceProvider::bootingPackage()` (safe after #125's lifecycle fix)
- New trait `LevelUp\Experience\Concerns\HasConfigurableIds` applied to all 13 package models — composes Laravel's `HasUniqueIds`, reads config at runtime, no-ops in `bigint` mode
- Polymorphic morph fix: `multiplier_scopes.scopeable_id` is now a `string` column with `(string) $key` casts at the three write/match sites in `Multiplier.php` — this is the follow-up #124 flagged in its "Out of scope" notes, addressed here because it's needed for (b) to work under any combination of the two ID-type knobs
- `LEVELUP_TEST_KEY_TYPE` env var drives `TestCase::getEnvironmentSetUp`, and the CI matrix gains `uuid` + `ulid` cells on PHP 8.3 + Laravel 12.* — the same 216-test suite runs under each of the three modes

## Why two knobs, not one

- `user.foreign_key_type` (#124, the (a) half) is dictated by whatever the host's User PK uses. Out of the package's control.
- `entities.id_type` (this PR) is the package's own decision about what its API exposes.

Coupling them forces hacks in legitimate mismatched scenarios (e.g. a bigint User table but UUID package IDs). They land as siblings.

## Backwards compatibility

Default `'bigint'` is **byte-identical** to today. Existing installs see no change on `composer update`:

- `HasConfigurableIds::uniqueIds()` returns `[]` in bigint mode, so `HasUniqueIds`' creating hook is a no-op
- `getKeyType()` returns `'int'`, `getIncrementing()` returns `true`
- The `entityId()`/`entityForeignId()` macros expand to the same `id()` / `foreignId()` calls
- `multiplier_scopes.scopeable_id` becomes `string` but SQLite/MySQL type affinity accepts ints transparently, and the `(string)` casts in `Multiplier.php` keep Postgres strict mode correct

## Existing installs

This setting only changes how *new* migrations build their tables. Existing installs can't be flipped automatically because column types are baked in. The README's new "Customizing Identifiers" section contains a copy-paste-able AI prompt that generates the conversion migrations tailored to your schema and database driver. The v2 upgrade skill gains a Step 9 that asks the user whether to switch and points to that section.

## Out of scope

- Automated conversion for existing installs (handled by the README AI prompt)
- A `scopeable_type` morph map for short aliases
- A runtime guard checking `Schema::getColumnType()` matches config