### PR TITLE
[2.x] fix(postgres+config): Postgres morph compatibility and v1→v2 config-merge upgrade fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ All notable changes to `level-up` will be documented in this file.
 ### Deprecated
 - The top-level `'table'` config key is deprecated in favour of `'tables.experiences'`. The old key still works as a fallback for existing installs — no action required.
 
+## v2.1.0 - 2026-05-24
+
+### Fixed
+- **PostgreSQL: `Multiplier::scopeTo()` with User or Tier targets now works.** Eloquent's morph join previously generated `multiplier_scopes.scopeable_id = tiers.id`, which Postgres rejects as a varchar/bigint type mismatch. A new `MorphToManyWithTextCast` relation class wraps the join key in `CAST(... AS TEXT)` on `pgsql` connections only; MySQL and SQLite are unchanged. The workaround will be removed in v3 when `multiplier_scopes` is replaced with typed pivot tables.
+- **v1.x → v2.x upgrade no longer crashes on `addPoints()`.** Laravel's `mergeConfigFrom` is a shallow merge, so v1.x users whose published `config/level-up.php` lacked the v2-era `models` block hit a null-class instantiation in the points listener. The service provider now deep-merges the package's bundled defaults into the published config at runtime, so any missing keys fall back to package defaults while user-set keys are preserved.
+
+### Documentation
+- Added `## v2.0 -> v2.1` section to `UPGRADE.md` with database compatibility notes and an explicit callout that feature toggles (`tiers.enabled`, `multipliers.enabled`, `challenges.enabled`) now default to `true` for v1.x upgraders — explicitly disable them in your published config if you don't want them.
+- Added `CONTRIBUTING.md` with Laravel-style branch policy.
+
 ## v2.0.0 - 2026-04-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/cjmellor/level-up?color=rgb%2856%20189%20248%29&label=release&style=for-the-badge)](https://packagist.org/packages/cjmellor/level-up)
-[![GitHub Tests Action Status](https://img.shields.io/github/actions/workflow/status/cjmellor/level-up/run-tests.yml?branch=main&label=tests&style=for-the-badge&color=rgb%28134%20239%20128%29)](https://github.com/cjmellor/level-up/actions?query=workflow%3Arun-tests+branch%3Amain)
+[![GitHub Tests Action Status](https://img.shields.io/github/actions/workflow/status/cjmellor/level-up/run-tests.yml?branch=2.x&label=tests&style=for-the-badge&color=rgb%28134%20239%20128%29)](https://github.com/cjmellor/level-up/actions?query=workflow%3Arun-tests+branch%3A2.x)
 [![Total Downloads](https://img.shields.io/packagist/dt/cjmellor/level-up.svg?color=rgb%28249%20115%2022%29&style=for-the-badge)](https://packagist.org/packages/cjmellor/level-up)
 ![Packagist PHP Version](https://img.shields.io/packagist/dependency-v/cjmellor/level-up/php?color=rgb%28165%20180%20252%29&logo=php&logoColor=rgb%28165%20180%20252%29&style=for-the-badge)
 ![Laravel Version](https://img.shields.io/badge/laravel-^12|^13-rgb(235%2068%2050)?style=for-the-badge&logo=laravel)

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,53 @@
 # Upgrade Guide
 
+## v2.0 -> v2.1
+
+v2.1 is a bug-fix release. No public API changes, no schema changes. Most upgraders need only update Composer; the two fixes below take effect automatically.
+
+### PostgreSQL: Multiplier scoping now works
+
+**Likelihood Of Impact: High** (Postgres users with tier-scoped or user-scoped multipliers); **None** (MySQL, SQLite, or non-scoped multipliers).
+
+Before v2.1, calling `$multiplier->tiers` or `$multiplier->users` on PostgreSQL raised `SQLSTATE[42883]: operator does not exist: bigint = character varying`. The morph pivot column (`multiplier_scopes.scopeable_id`) is varchar, and Postgres refuses to implicitly compare it against the related model's bigint/uuid primary key.
+
+v2.1 ships a Postgres-specific cast in the join clause. No user action required. MySQL and SQLite are unchanged — the cast only activates on `pgsql` connections.
+
+This workaround will be removed in v3, when `multiplier_scopes` is replaced with two typed pivot tables.
+
+### Config: published configs from v1.x are now backfilled
+
+**Likelihood Of Impact: Critical** (users who upgraded from v1.x and published their config before v2.0); **None** (fresh v2.x installs).
+
+Before v2.1, an app that had published `config/level-up.php` under v1.x crashed on `addPoints()` after upgrading to v2.x. The cause: Laravel's `mergeConfigFrom` is a shallow merge, so the v2-era `models` block in the package's bundled config was overridden by its absence in the published file. `config('level-up.models.experience')` returned `null`, and the points-increased listener tried to instantiate a null class.
+
+v2.1 backfills missing config keys with package defaults at runtime. Your published config is still the source of truth for anything you have set; only keys absent from your published config fall back to defaults. No action required.
+
+### Heads-up: feature toggles now default to `true` after upgrade
+
+**Likelihood Of Impact: Medium** (v1.x users upgrading whose published config predates the new feature toggles).
+
+A side-effect of the config fix above: keys like `level-up.tiers.enabled`, `level-up.multipliers.enabled`, and `level-up.challenges.enabled` — which didn't exist in v1.x — now fall back to their bundled defaults, which are `true`. Before v2.1, the shallow-merge bug accidentally made these features look "off" (the keys returned `null`) for upgraders.
+
+If you upgraded from v1.x and **do not** want tiers, multipliers, or challenges enabled, explicitly set them in your published config:
+
+```php
+// config/level-up.php
+return [
+    // ...
+    'tiers' => ['enabled' => false],
+    'multipliers' => ['enabled' => false],
+    'challenges' => ['enabled' => false],
+];
+```
+
+Fresh v2.x installs are unaffected — their published config already reflects the intended defaults.
+
+### Database compatibility notes
+
+- **PostgreSQL:** now fully supported across all features, including `Multiplier::scopeTo()`. PostgreSQL 14+ recommended.
+- **MySQL:** no known limitations. MySQL 8.0+ recommended.
+- **SQLite:** supported, but ensure foreign-key enforcement is enabled (`PRAGMA foreign_keys = ON`) — Laravel does this by default, but check your `database.php` connection config if you've customised it.
+
 ## v1.x -> v2.0
 
 ### Requirements

--- a/src/Database/Eloquent/Relations/MorphToManyWithTextCast.php
+++ b/src/Database/Eloquent/Relations/MorphToManyWithTextCast.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LevelUp\Experience\Database\Eloquent\Relations;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\MorphToMany;
+use Illuminate\Database\Query\JoinClause;
+
+/**
+ * MorphToMany variant that casts the related table's key to text before
+ * comparing it against the pivot's polymorphic id column.
+ *
+ * Postgres rejects implicit comparisons between bigint/uuid and varchar
+ * (the type of `multiplier_scopes.scopeable_id`). MySQL and SQLite coerce
+ * silently. The cast is only applied on Postgres connections; other drivers
+ * use the standard parent join unchanged.
+ */
+class MorphToManyWithTextCast extends MorphToMany
+{
+    protected function performJoin($query = null)
+    {
+        $query = $query ?: $this->query;
+
+        if ($this->driverName($query) !== 'pgsql') {
+            return parent::performJoin($query);
+        }
+
+        $relatedKey = $this->related->getTable().'.'.$this->relatedKey;
+        $pivotKey = $this->getQualifiedRelatedPivotKeyName();
+
+        $grammar = $query->getQuery()->getGrammar();
+        $wrappedRelatedKey = $grammar->wrap($relatedKey);
+        $wrappedPivotKey = $grammar->wrap($pivotKey);
+
+        $query->join($this->table, function (JoinClause $join) use ($wrappedPivotKey, $wrappedRelatedKey): void {
+            $join->whereRaw("{$wrappedPivotKey} = CAST({$wrappedRelatedKey} AS TEXT)");
+        });
+
+        return $this;
+    }
+
+    private function driverName(Builder $query): string
+    {
+        return $query->getQuery()->getConnection()->getDriverName();
+    }
+}

--- a/src/Database/Eloquent/Relations/MorphToManyWithTextCast.php
+++ b/src/Database/Eloquent/Relations/MorphToManyWithTextCast.php
@@ -8,15 +8,6 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Illuminate\Database\Query\JoinClause;
 
-/**
- * MorphToMany variant that casts the related table's key to text before
- * comparing it against the pivot's polymorphic id column.
- *
- * Postgres rejects implicit comparisons between bigint/uuid and varchar
- * (the type of `multiplier_scopes.scopeable_id`). MySQL and SQLite coerce
- * silently. The cast is only applied on Postgres connections; other drivers
- * use the standard parent join unchanged.
- */
 class MorphToManyWithTextCast extends MorphToMany
 {
     protected function performJoin($query = null)

--- a/src/LevelUpServiceProvider.php
+++ b/src/LevelUpServiceProvider.php
@@ -108,8 +108,28 @@ class LevelUpServiceProvider extends PackageServiceProvider
     {
         parent::register();
 
+        $this->mergePackageDefaults();
+
         $this->app->register(provider: EventServiceProvider::class);
         $this->app->singleton(abstract: 'leaderboard', concrete: fn (): LeaderboardService => new LeaderboardService());
+    }
+
+    /**
+     * Backfill the published config with the package's bundled defaults.
+     *
+     * Spatie's hasConfigFile() uses Laravel's shallow mergeConfigFrom, so a
+     * user's published config from an earlier version is missing any keys we
+     * have added since (e.g. the models block). Deep-merging here means
+     * upgrades don't crash on undefined config reads.
+     */
+    protected function mergePackageDefaults(): void
+    {
+        $defaults = require __DIR__.'/../config/level-up.php';
+
+        config()->set('level-up', array_replace_recursive(
+            $defaults,
+            (array) config('level-up', []),
+        ));
     }
 
     protected function registerEntityKeyMacros(): void

--- a/src/LevelUpServiceProvider.php
+++ b/src/LevelUpServiceProvider.php
@@ -114,14 +114,6 @@ class LevelUpServiceProvider extends PackageServiceProvider
         $this->app->singleton(abstract: 'leaderboard', concrete: fn (): LeaderboardService => new LeaderboardService());
     }
 
-    /**
-     * Backfill the published config with the package's bundled defaults.
-     *
-     * Spatie's hasConfigFile() uses Laravel's shallow mergeConfigFrom, so a
-     * user's published config from an earlier version is missing any keys we
-     * have added since (e.g. the models block). Deep-merging here means
-     * upgrades don't crash on undefined config reads.
-     */
     protected function mergePackageDefaults(): void
     {
         $defaults = require __DIR__.'/../config/level-up.php';

--- a/src/Models/Multiplier.php
+++ b/src/Models/Multiplier.php
@@ -44,32 +44,6 @@ class Multiplier extends Model
             ->using(config(key: 'level-up.models.multiplier_scope'));
     }
 
-    protected function newMorphToMany(
-        $query,
-        Model $parent,
-        $name,
-        $table,
-        $foreignPivotKey,
-        $relatedPivotKey,
-        $parentKey,
-        $relatedKey,
-        $relationName = null,
-        $inverse = false,
-    ): MorphToMany {
-        return new MorphToManyWithTextCast(
-            $query,
-            $parent,
-            $name,
-            $table,
-            $foreignPivotKey,
-            $relatedPivotKey,
-            $parentKey,
-            $relatedKey,
-            $relationName,
-            $inverse,
-        );
-    }
-
     public function scopeTo(Model ...$models): static
     {
         foreach ($models as $model) {
@@ -97,6 +71,32 @@ class Multiplier extends Model
                 message: 'starts_at must be before expires_at.',
             );
         });
+    }
+
+    protected function newMorphToMany(
+        $query,
+        Model $parent,
+        $name,
+        $table,
+        $foreignPivotKey,
+        $relatedPivotKey,
+        $parentKey,
+        $relatedKey,
+        $relationName = null,
+        $inverse = false,
+    ): MorphToMany {
+        return new MorphToManyWithTextCast(
+            $query,
+            $parent,
+            $name,
+            $table,
+            $foreignPivotKey,
+            $relatedPivotKey,
+            $parentKey,
+            $relatedKey,
+            $relationName,
+            $inverse,
+        );
     }
 
     #[Scope]

--- a/src/Models/Multiplier.php
+++ b/src/Models/Multiplier.php
@@ -12,6 +12,7 @@ use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use InvalidArgumentException;
 use LevelUp\Experience\Concerns\HasConfigurableIds;
 use LevelUp\Experience\Concerns\ResolvesConfiguredTable;
+use LevelUp\Experience\Database\Eloquent\Relations\MorphToManyWithTextCast;
 
 class Multiplier extends Model
 {
@@ -41,6 +42,32 @@ class Multiplier extends Model
     {
         return $this->morphedByMany(config(key: 'level-up.user.model'), 'scopeable', config('level-up.tables.multiplier_scopes'))
             ->using(config(key: 'level-up.models.multiplier_scope'));
+    }
+
+    protected function newMorphToMany(
+        $query,
+        Model $parent,
+        $name,
+        $table,
+        $foreignPivotKey,
+        $relatedPivotKey,
+        $parentKey,
+        $relatedKey,
+        $relationName = null,
+        $inverse = false,
+    ): MorphToMany {
+        return new MorphToManyWithTextCast(
+            $query,
+            $parent,
+            $name,
+            $table,
+            $foreignPivotKey,
+            $relatedPivotKey,
+            $parentKey,
+            $relatedKey,
+            $relationName,
+            $inverse,
+        );
     }
 
     public function scopeTo(Model ...$models): static


### PR DESCRIPTION
## Summary

Two independent bug fixes for v2.x, both surfaced during a multi-driver E2E test sweep against PR #128. No public API changes, no schema changes.

### Fix 1 — PostgreSQL: `Multiplier::scopeTo()` now works

Eloquent's morph join previously generated `multiplier_scopes.scopeable_id = tiers.id`, which Postgres rejects as a varchar/bigint type mismatch (`SQLSTATE[42883]: operator does not exist`). MySQL and SQLite coerce silently.

New `MorphToManyWithTextCast` relation class wraps the join key in `CAST(... AS TEXT)` on `pgsql` connections only. Falls through to parent `performJoin()` on other drivers, so MySQL/SQLite are unchanged. Wired in via a `newMorphToMany()` override on `Multiplier`.

This is a transitional fix — v3 will redesign `multiplier_scopes` into two typed pivot tables (`multiplier_user` + `multiplier_tier`), at which point this class is deleted.

### Fix 2 — v1.x → v2.x upgraders no longer crash on `addPoints()`

Spatie's `hasConfigFile()` calls Laravel's `mergeConfigFrom`, which is a shallow merge. An app that published `config/level-up.php` under v1.x lacks the v2-era `models` block — so `config('level-up.models.experience')` returned `null`, and `PointsIncreasedListener::checkTierPromotion()` tried to instantiate a null class on first `addPoints()` call.

`LevelUpServiceProvider::register()` now runs `array_replace_recursive` against the bundled defaults right after Spatie's shallow merge. Missing keys fall back to defaults; explicitly set keys are preserved. Fixes the upgrade path without requiring users to re-publish their config.

## Heads-up: feature toggles now default `true`

The deep-merge fix has a side-effect documented in `UPGRADE.md`: v1.x upgraders whose published config predates the new feature toggles (`tiers.enabled`, `multipliers.enabled`, `challenges.enabled`) will now have those features active. Before this PR, the shallow-merge bug accidentally made them look "off" (the keys returned null). Fresh installs are unaffected. UPGRADE.md tells upgraders how to opt out explicitly if they don't want those features.

## Testing

- **Package Pest suite:** 240/0 (SQLite, default config)
- **Cross-driver matrix** (SQLite/MySQL/Postgres × bigint/UUID/ULID = 9 scenarios): all 38/0
- **v1.5.1 → patched-v2.x upgrade scenario:** `addPoints` succeeds, `config('level-up.models.experience')` resolves correctly, `models` block backfilled at runtime
- **Postgres scenarios specifically:** previously 33/5 (bigint), 36/2 (UUID), 37/1 (ULID); now 38/0 across the board with the morph cast

## Commits

1. `fix(postgres): cast morph join keys to text for pg compatibility`
2. `fix(config): deep-merge package defaults so upgraded configs backfill`
3. `docs(v2.1): UPGRADE notes and changelog entry`
4. `docs(readme): point CI badge at 2.x maintenance branch`

## Related

- Follow-up: v3 will remove `MorphToManyWithTextCast` by reshaping `multiplier_scopes` into two typed pivot tables. The deep-merge fix stays.