### PR TITLE
[3.x] fix(v3): repair alter_experience_audits_type_to_string Postgres rollback

### DIFF
--- a/database/migrations/alter_experience_audits_type_to_string.php.stub
+++ b/database/migrations/alter_experience_audits_type_to_string.php.stub
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration {
@@ -14,8 +15,23 @@ return new class extends Migration {
 
     public function down(): void
     {
-        Schema::table(config('level-up.tables.experience_audits'), function (Blueprint $table) {
-            $table->enum('type', ['add', 'remove', 'reset', 'level_up', 'tier_up', 'tier_down'])->change();
+        $table = config('level-up.tables.experience_audits');
+        $values = ['add', 'remove', 'reset', 'level_up', 'tier_up', 'tier_down'];
+
+        // Postgres rejects Laravel/Doctrine's `enum().change()` translation
+        // (it inlines CHECK into ALTER COLUMN TYPE, which is invalid). Apply
+        // the equivalent change as two separate statements on pgsql; other
+        // drivers use the standard Blueprint path.
+        if (DB::connection()->getDriverName() === 'pgsql') {
+            DB::statement("ALTER TABLE {$table} ALTER COLUMN type TYPE varchar(255)");
+            $values = "'".implode("', '", $values)."'";
+            DB::statement("ALTER TABLE {$table} ADD CONSTRAINT {$table}_type_check CHECK (type IN ({$values}))");
+
+            return;
+        }
+
+        Schema::table($table, function (Blueprint $blueprint) use ($values): void {
+            $blueprint->enum('type', $values)->change();
         });
     }
 };


### PR DESCRIPTION
## Summary

Reported by @christoph-kluge in discussion #121. The \`alter_experience_audits_type_to_string\` migration's \`down()\` failed on Postgres with:

\`\`\`
SQLSTATE[42601]: Syntax error: 7 ERROR: syntax error at or near "check"
LINE 1: ...nce_audits" alter column "type" type varchar(255) check ("ty...
\`\`\`

Cause: Laravel/Doctrine translates \`\$table->enum('type', [...])->change()\` on Postgres into a single \`ALTER COLUMN TYPE\` statement that inlines a \`check (...)\` clause. That syntax is invalid — Postgres requires CHECK constraints to be added via a separate \`ADD CONSTRAINT\`.

Fix: on \`pgsql\` connections, emit the two statements explicitly. MySQL and SQLite continue to use the existing Blueprint \`enum().change()\` path.

\`up()\` is unaffected — widening varchar works on all three drivers.

## Files changed

| File | Change |
|---|---|
| \`database/migrations/alter_experience_audits_type_to_string.php.stub\` | Driver-aware \`down()\` — raw DDL on pgsql, Blueprint chain on mysql/sqlite |

## Test plan

- [x] \`composer test\` — 240/0 (SQLite path unchanged)
- [x] \`composer lint\` — passes
- [ ] CI on this PR — pending
- [ ] Manual Postgres rollback test — not in package CI; christoph can re-verify after merge

## Related

- Closes the issue raised in #121 around line "🐛 \`2026_05_20_073816_alter_experience_audits_type_to_string\` does work with \`migrate:rollback\` with postgres"