### PR TITLE
ci: pin workflow actions to full-length commit SHAs

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -14,7 +14,7 @@ jobs:
 
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v3.1.0
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/run-linter.yml
+++ b/.github/workflows/run-linter.yml
@@ -9,13 +9,13 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Lint with Pint
-        uses: aglipanci/laravel-pint-action@2.6
+        uses: aglipanci/laravel-pint-action@36de00d5f5a8a4e12d443e01671daa12a18f4c79 # 2.6
 
       - name: Commit linted files
-        uses: stefanzweifel/git-auto-commit-action@v7
+        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7
         with:
           commit_message: "fix: Files linted with Pint"
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -38,10 +38,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
         with:
           php-version: ${{ matrix.php }}
           tools: composer:v2

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -13,18 +13,18 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: main
 
       - name: Update CHANGELOG
-        uses: stefanzweifel/changelog-updater-action@v1
+        uses: stefanzweifel/changelog-updater-action@a938690fad7edf25368f37e43a1ed1b34303eb36 # v1
         with:
           latest-version: ${{ github.event.release.name }}
           release-notes: ${{ github.event.release.body }}
 
       - name: Commit updated CHANGELOG
-        uses: stefanzweifel/git-auto-commit-action@v7
+        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7
         with:
           branch: main
           commit_message: Update CHANGELOG

--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,5 @@ phpstan.neon
 testbench.yaml
 vendor
 node_modules
-.claude/review-history.json
+.claude
 .env


### PR DESCRIPTION
## What

Pins every GitHub Actions `uses:` ref in the workflow files to a full-length commit SHA, keeping the original tag as a trailing comment for readability.

| Action | Pinned to | Tag |
|--------|-----------|-----|
| `dependabot/fetch-metadata` | `25dd0e3` | v3.1.0 |
| `actions/checkout` | `de0fac2` | v6 |
| `shivammathur/setup-php` | `7c071df` | v2 |
| `stefanzweifel/changelog-updater-action` | `a938690` | v1 |
| `stefanzweifel/git-auto-commit-action` | `04702ed` | v7 |
| `aglipanci/laravel-pint-action` | `36de00d` | 2.6 |

9 refs across 4 workflow files (`dependabot-auto-merge`, `run-tests`, `run-linter`, `update-changelog`).

## Why

Tags and branches are mutable. When `tj-actions/changed-files` was compromised in 2025, the attacker repointed existing tags, so every workflow using `@v1` instantly ran malicious code. Pinning to a full commit SHA makes that impossible. The repo-level "Require actions to be pinned to a full-length commit SHA" setting (now enabled) prevents unpinned refs from being reintroduced.

## Notes

- The trailing `# vX` comment preserves the tracked version, so Dependabot continues to bump these actions normally.
- No behavioural change — each SHA is the commit the tag currently resolves to.