### PR TITLE
ci: run Pint in check-only mode instead of auto-committing

### DIFF
--- a/.github/workflows/run-linter.yml
+++ b/.github/workflows/run-linter.yml
@@ -8,17 +8,12 @@ permissions:
 jobs:
   lint:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Lint with Pint
+      - name: Check code style with Pint
         uses: aglipanci/laravel-pint-action@36de00d5f5a8a4e12d443e01671daa12a18f4c79 # 2.6
-
-      - name: Commit linted files
-        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7
         with:
-          commit_message: "fix: Files linted with Pint"
+          testMode: true
 


### PR DESCRIPTION
## What

Changes the linter workflow from **auto-fix-and-commit** to **check-only**:

- Pint runs with `testMode: true` — the job fails if any file isn't formatted, instead of committing fixes back to the PR.
- Removes the `git-auto-commit-action` step.
- Drops the job-level `contents: write` grant, so the workflow now runs entirely under the read-only default token.

## Why

Part of the CI hardening pass. With write removed, `run-linter` no longer contributes to the "workflow permissions are restricted" finding — a compromised action in this workflow can no longer push to the repo.

## Behaviour change

Contributors now run Pint locally (`composer format`) and push the fix themselves; CI no longer commits formatting changes on their behalf. This mirrors the local `composer lint` / `composer dry-format` tooling.

## Note

`update-changelog` and `dependabot-auto-merge` still require write for their core function (committing the changelog, merging PRs), so they keep job-scoped write. The permissions finding's flagged count drops but won't reach zero without moving those to an App/PAT token.