### PR TITLE
feat(v3): rank leaderboards by any metric via RankingMetric contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -561,18 +561,34 @@ public int $amount,
 
 ## 📈 Leaderboard
 
-The package also includes a leaderboard feature to track and display user rankings based on their experience points.
-
-The Leaderboard comes as a Service.
+The package includes a metric-driven leaderboard. A leaderboard ranks users by a **metric** — experience points by default — and returns `LeaderboardEntry` objects exposing the `user` and their `score`.
 
 ```php
-Leaderboard::generate();
+$entries = Leaderboard::generate();
+
+foreach ($entries as $entry) {
+    $entry->user;  // the User model (with Experience eager-loaded)
+    $entry->score; // the user's score on this metric
+}
 ```
 
-This generates a User model along with its Experience and Level data and ordered by the Users’ experience points.
+Pass `paginate: true` for a paginator of entries, or `limit:` to cap the result count.
 
-> The Leaderboard is very basic and has room for improvement
->
+### Choosing a metric
+
+Metrics are registered in the config under `level-up.leaderboard.metrics`, and the default lives at `level-up.leaderboard.default_metric`. Select one explicitly with `by()` — it accepts a registry key, a class-string, or a metric instance:
+
+```php
+Leaderboard::by('xp')->generate();
+Leaderboard::by(MyCustomMetric::class)->generate();
+Leaderboard::by(new MyCustomMetric())->generate();
+```
+
+An unknown key throws `MetricNotFoundException`; a metric whose underlying feature is disabled throws `MetricDisabledException` rather than returning an empty board.
+
+### Custom metrics
+
+Rank by anything you can express as a SQL score: implement `LevelUp\Experience\Contracts\RankingMetric` — a stable `key()`, a `label()`, an `enabled()` check, a `constrain()` that scopes the user query to eligible users, and a `scoreExpression()` subquery yielding one numeric score per user — then register the class in `level-up.leaderboard.metrics`.
 
 ## 🔍 Auditing
 

--- a/config/level-up.php
+++ b/config/level-up.php
@@ -102,6 +102,23 @@ return [
 
     /*
     |-----------------------------------------------------------------------
+    | Leaderboard
+    |-----------------------------------------------------------------------
+    |
+    | Configure the leaderboard. 'metrics' maps registry keys to
+    | RankingMetric classes — register custom metrics by adding entries.
+    | 'default_metric' is used when no metric is specified.
+    |
+    */
+    'leaderboard' => [
+        'default_metric' => 'xp',
+        'metrics' => [
+            'xp' => LevelUp\Experience\Metrics\ExperienceMetric::class,
+        ],
+    ],
+
+    /*
+    |-----------------------------------------------------------------------
     | Starting Level
     |-----------------------------------------------------------------------
     |

--- a/resources/boost/skills/level-up-development/SKILL.md
+++ b/resources/boost/skills/level-up-development/SKILL.md
@@ -552,13 +552,15 @@ Reference it in the condition: `['type' => 'custom', 'class' => HasVerifiedEmail
 ```php
 use LevelUp\Experience\Facades\Leaderboard;
 
-Leaderboard::generate();                        // All users by XP
+Leaderboard::generate();                        // Default metric (XP), score descending
 Leaderboard::generate(paginate: true);          // Paginated
 Leaderboard::generate(limit: 10);              // Top 10
+Leaderboard::by('xp')->generate();              // Explicit metric key
+Leaderboard::by(MyMetric::class)->generate();   // Custom metric (class or instance)
 Leaderboard::forTier('Gold')->generate();       // Gold tier only
 ```
 
-Returns User models with `experience` relationship eager-loaded, ordered by XP descending.
+Returns `LeaderboardEntry` objects — `$entry->user` (with `experience` eager-loaded) and `$entry->score` — ordered by score descending. Metrics are registered in `level-up.leaderboard.metrics` (custom ones implement `LevelUp\Experience\Contracts\RankingMetric`); unknown keys throw `MetricNotFoundException`, disabled-feature metrics throw `MetricDisabledException`.
 
 ## Auditing
 

--- a/src/Contracts/RankingMetric.php
+++ b/src/Contracts/RankingMetric.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LevelUp\Experience\Contracts;
+
+use Illuminate\Contracts\Database\Query\Builder;
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
+
+interface RankingMetric
+{
+    public function key(): string;
+
+    public function label(): string;
+
+    public function enabled(): bool;
+
+    public function constrain(EloquentBuilder $query): EloquentBuilder;
+
+    public function scoreExpression(): Builder;
+}

--- a/src/Exceptions/MetricDisabledException.php
+++ b/src/Exceptions/MetricDisabledException.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LevelUp\Experience\Exceptions;
+
+use Exception;
+use LevelUp\Experience\Contracts\RankingMetric;
+
+final class MetricDisabledException extends Exception
+{
+    public static function forMetric(RankingMetric $metric): self
+    {
+        return new self(message: "The [{$metric->key()}] leaderboard metric is disabled because its underlying feature is turned off.");
+    }
+}

--- a/src/Exceptions/MetricNotFoundException.php
+++ b/src/Exceptions/MetricNotFoundException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LevelUp\Experience\Exceptions;
+
+use Exception;
+
+final class MetricNotFoundException extends Exception
+{
+    public static function forKey(string $key): self
+    {
+        return new self(message: "No leaderboard metric is registered for key [{$key}]. Register it under 'level-up.leaderboard.metrics'.");
+    }
+}

--- a/src/Metrics/ExperienceMetric.php
+++ b/src/Metrics/ExperienceMetric.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LevelUp\Experience\Metrics;
+
+use Illuminate\Contracts\Database\Query\Builder;
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
+use LevelUp\Experience\Contracts\RankingMetric;
+
+class ExperienceMetric implements RankingMetric
+{
+    public function key(): string
+    {
+        return 'xp';
+    }
+
+    public function label(): string
+    {
+        return 'Experience';
+    }
+
+    public function enabled(): bool
+    {
+        return true;
+    }
+
+    public function constrain(EloquentBuilder $query): EloquentBuilder
+    {
+        return $query->whereHas(
+            relation: 'experience',
+            callback: fn (EloquentBuilder $query): EloquentBuilder => $query->whereNotNull(columns: 'experience_points'),
+        );
+    }
+
+    public function scoreExpression(): Builder
+    {
+        $experienceModel = config(key: 'level-up.models.experience');
+
+        return $experienceModel::query()
+            ->select(columns: 'experience_points')
+            ->whereColumn(
+                first: config(key: 'level-up.user.foreign_key'),
+                operator: '=',
+                second: config(key: 'level-up.user.users_table').'.id',
+            )
+            ->latest()
+            ->take(value: 1)
+            ->toBase();
+    }
+}

--- a/src/Services/LeaderboardService.php
+++ b/src/Services/LeaderboardService.php
@@ -4,11 +4,15 @@ declare(strict_types=1);
 
 namespace LevelUp\Experience\Services;
 
-use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Collection;
-use LevelUp\Experience\Models\Experience;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Support\Collection;
+use LevelUp\Experience\Contracts\RankingMetric;
+use LevelUp\Experience\Exceptions\MetricDisabledException;
+use LevelUp\Experience\Exceptions\MetricNotFoundException;
 use LevelUp\Experience\Models\Tier;
+use LevelUp\Experience\Support\LeaderboardEntry;
 
 class LeaderboardService
 {
@@ -16,9 +20,18 @@ class LeaderboardService
 
     private ?Tier $tier = null;
 
+    private ?RankingMetric $metric = null;
+
     public function __construct()
     {
         $this->userModel = config(key: 'level-up.user.model');
+    }
+
+    public function by(string|RankingMetric $metric): static
+    {
+        $this->metric = $this->resolveMetric($metric);
+
+        return $this;
     }
 
     public function forTier(string|Tier $tier): static
@@ -33,25 +46,58 @@ class LeaderboardService
         return $this;
     }
 
-    public function generate(bool $paginate = false, ?int $limit = null): array|Collection|LengthAwarePaginator
+    public function generate(bool $paginate = false, ?int $limit = null): Collection|LengthAwarePaginator
     {
         [$tier, $this->tier] = [$this->tier, null];
+        [$metric, $this->metric] = [$this->metric ?? $this->defaultMetric(), null];
 
-        return $this->userModel::query()
+        throw_unless($metric->enabled(), exception: MetricDisabledException::forMetric($metric));
+
+        $users = $this->userModel::query()
+            ->select(columns: config(key: 'level-up.user.users_table').'.*')
+            ->selectSub(query: $metric->scoreExpression(), as: 'score')
             ->with(relations: ['experience'])
-            ->whereHas('experience', function (Builder $query) use ($tier): void {
-                $query->whereNotNull(columns: 'experience_points');
-
-                if ($tier instanceof Tier) {
-                    $query->where(column: 'tier_id', operator: '=', value: $tier->id);
-                }
-            })
-            ->orderByDesc(
-                column: Experience::query()->select('experience_points')
-                    ->whereColumn(config('level-up.user.foreign_key'), config('level-up.user.users_table').'.id')
-                    ->latest()
-            )
-            ->take($limit)
+            ->tap(callback: fn (Builder $query): Builder => $metric->constrain($query))
+            ->when($tier instanceof Tier, fn (Builder $query): Builder => $query->whereHas(
+                'experience',
+                fn (Builder $query): Builder => $query->where(column: 'tier_id', operator: '=', value: $tier->id),
+            ))
+            ->orderByDesc(column: 'score')
+            ->take(value: $limit)
             ->when($paginate, fn (Builder $query) => $query->paginate(), fn (Builder $query) => $query->get());
+
+        return $users instanceof LengthAwarePaginator
+            ? $users->through(callback: fn (Model $user): LeaderboardEntry => $this->toEntry($user))
+            : $users->map(callback: fn (Model $user): LeaderboardEntry => $this->toEntry($user));
+    }
+
+    private function toEntry(Model $user): LeaderboardEntry
+    {
+        $score = $user->getAttribute(key: 'score') + 0;
+
+        unset($user->score);
+
+        return new LeaderboardEntry(user: $user, score: $score);
+    }
+
+    private function defaultMetric(): RankingMetric
+    {
+        return $this->resolveMetric(config(key: 'level-up.leaderboard.default_metric'));
+    }
+
+    private function resolveMetric(string|RankingMetric $metric): RankingMetric
+    {
+        if ($metric instanceof RankingMetric) {
+            return $metric;
+        }
+
+        $metricClass = config(
+            key: "level-up.leaderboard.metrics.{$metric}",
+            default: is_subclass_of($metric, RankingMetric::class) ? $metric : null,
+        );
+
+        throw_unless($metricClass, exception: MetricNotFoundException::forKey($metric));
+
+        return resolve(name: $metricClass);
     }
 }

--- a/src/Support/LeaderboardEntry.php
+++ b/src/Support/LeaderboardEntry.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LevelUp\Experience\Support;
+
+use Illuminate\Database\Eloquent\Model;
+
+final readonly class LeaderboardEntry
+{
+    public function __construct(
+        public Model $user,
+        public int|float $score,
+    ) {}
+}

--- a/tests/Concerns/HasTiersIntegrationTest.php
+++ b/tests/Concerns/HasTiersIntegrationTest.php
@@ -104,5 +104,5 @@ test(description: 'leaderboard can be filtered by tier', closure: function (): v
     $silverLeaderboard = resolve('leaderboard')->forTier('Silver')->generate();
 
     expect($silverLeaderboard)->toHaveCount(count: 1)
-        ->and($silverLeaderboard->first()->id)->toBe(expected: $this->user->id);
+        ->and($silverLeaderboard->first()->user->id)->toBe(expected: $this->user->id);
 });

--- a/tests/Fixtures/UserIdMetric.php
+++ b/tests/Fixtures/UserIdMetric.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LevelUp\Experience\Tests\Fixtures;
+
+use Illuminate\Contracts\Database\Query\Builder;
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
+use Illuminate\Support\Facades\DB;
+use LevelUp\Experience\Contracts\RankingMetric;
+
+class UserIdMetric implements RankingMetric
+{
+    public function __construct(private readonly bool $enabled = true) {}
+
+    public function key(): string
+    {
+        return 'user-id';
+    }
+
+    public function label(): string
+    {
+        return 'User ID';
+    }
+
+    public function enabled(): bool
+    {
+        return $this->enabled;
+    }
+
+    public function constrain(EloquentBuilder $query): EloquentBuilder
+    {
+        return $query;
+    }
+
+    public function scoreExpression(): Builder
+    {
+        return DB::table('users', as: 'score_source')
+            ->select(columns: 'score_source.id')
+            ->whereColumn(first: 'score_source.id', operator: '=', second: 'users.id');
+    }
+}

--- a/tests/Services/LeaderboardServiceTest.php
+++ b/tests/Services/LeaderboardServiceTest.php
@@ -4,33 +4,124 @@ declare(strict_types=1);
 
 uses()->group('leaderboard');
 
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use LevelUp\Experience\Exceptions\MetricDisabledException;
+use LevelUp\Experience\Exceptions\MetricNotFoundException;
 use LevelUp\Experience\Facades\Leaderboard;
+use LevelUp\Experience\Metrics\ExperienceMetric;
+use LevelUp\Experience\Support\LeaderboardEntry;
 use LevelUp\Experience\Tests\Fixtures\User;
+use LevelUp\Experience\Tests\Fixtures\UserIdMetric;
 
 beforeEach(function (): void {
     config(['level-up.user.model' => User::class]);
     config(['level-up.multiplier.enabled' => false]);
 });
 
-it(description: 'returns the correct data in the correct order', closure: function (): void {
+it(description: 'generates leaderboard entries with user and score, ordered by score descending', closure: function (): void {
     tap(User::newFactory()->create())->addPoints(44);
     tap(User::newFactory()->create())->addPoints(123);
     tap(User::newFactory()->create())->addPoints(198);
     tap(User::newFactory()->create())->addPoints(245);
 
-    expect(
-        Leaderboard::generate()
-            ->pluck(value: 'experience.experience_points')
-            ->toArray()
-    )
-        ->toBe([245, 198, 123, 44])
-        ->toHaveCount(count: 4);
+    $entries = Leaderboard::generate();
+
+    expect($entries)->toHaveCount(count: 4)
+        ->and($entries->first())->toBeInstanceOf(class: LeaderboardEntry::class)
+        ->and($entries->first()->user)->toBeInstanceOf(class: User::class)
+        ->and($entries->map(fn (LeaderboardEntry $entry): int => $entry->score)->toArray())
+        ->toBe([245, 198, 123, 44]);
 });
 
-it(description: 'only shows users with experience points', closure: function (): void {
+it(description: 'ranks by an explicitly selected metric key', closure: function (): void {
+    tap(User::newFactory()->create())->addPoints(44);
+    tap(User::newFactory()->create())->addPoints(123);
+
+    $entries = Leaderboard::by(metric: 'xp')->generate();
+
+    expect($entries->map(fn (LeaderboardEntry $entry): int => $entry->score)->toArray())
+        ->toBe([123, 44]);
+});
+
+it(description: 'throws for an unknown metric key', closure: function (): void {
+    Leaderboard::by(metric: 'nonsense');
+})->throws(exception: MetricNotFoundException::class, exceptionMessage: 'nonsense');
+
+it(description: 'ranks by a custom metric resolved from its class name', closure: function (): void {
+    tap(User::newFactory()->create())->addPoints(999);
+    tap(User::newFactory()->create())->addPoints(1);
+
+    $entries = Leaderboard::by(metric: UserIdMetric::class)->generate();
+
+    expect($entries->map(fn (LeaderboardEntry $entry): int|float => $entry->score)->toArray())
+        ->toBe([3, 2, 1]);
+});
+
+it(description: 'ranks by a custom metric instance', closure: function (): void {
+    tap(User::newFactory()->create())->addPoints(999);
+    tap(User::newFactory()->create())->addPoints(1);
+
+    $entries = Leaderboard::by(metric: new UserIdMetric())->generate();
+
+    expect($entries->first()->score)->toBe(3);
+});
+
+it(description: 'uses the configured default metric for a bare generate call', closure: function (): void {
+    config([
+        'level-up.leaderboard.metrics.user-id' => UserIdMetric::class,
+        'level-up.leaderboard.default_metric' => 'user-id',
+    ]);
+
+    tap(User::newFactory()->create())->addPoints(999);
+
+    $entries = Leaderboard::generate();
+
+    expect($entries)->toHaveCount(count: 2)
+        ->and($entries->first()->score)->toBe(2);
+});
+
+it(description: 'throws when generating with a metric whose feature is disabled', closure: function (): void {
+    Leaderboard::by(metric: new UserIdMetric(enabled: false))->generate();
+})->throws(exception: MetricDisabledException::class, exceptionMessage: 'user-id');
+
+it(description: 'paginates leaderboard entries', closure: function (): void {
+    tap(User::newFactory()->create())->addPoints(44);
+    tap(User::newFactory()->create())->addPoints(123);
+
+    $paginated = Leaderboard::generate(paginate: true);
+
+    expect($paginated)->toBeInstanceOf(class: LengthAwarePaginator::class)
+        ->and($paginated->total())->toBe(expected: 2)
+        ->and($paginated->items()[0])->toBeInstanceOf(class: LeaderboardEntry::class)
+        ->and($paginated->items()[0]->score)->toBe(expected: 123);
+});
+
+it(description: 'limits the number of leaderboard entries', closure: function (): void {
+    tap(User::newFactory()->create())->addPoints(44);
+    tap(User::newFactory()->create())->addPoints(123);
+    tap(User::newFactory()->create())->addPoints(198);
+
+    $entries = Leaderboard::generate(limit: 2);
+
+    expect($entries)->toHaveCount(count: 2)
+        ->and($entries->map(fn (LeaderboardEntry $entry): int => $entry->score)->toArray())
+        ->toBe([198, 123]);
+});
+
+it(description: 'exposes a stable key and label on the experience metric', closure: function (): void {
+    $metric = new ExperienceMetric();
+
+    expect($metric->key())->toBe(expected: 'xp')
+        ->and($metric->label())->toBe(expected: 'Experience')
+        ->and($metric->enabled())->toBeTrue();
+});
+
+it(description: 'only includes users with experience points', closure: function (): void {
     tap(User::newFactory()->create());
     $userWithPoints = tap(User::newFactory()->create())->addPoints(44);
 
-    expect(Leaderboard::generate())->toHaveCount(count: 1)
-        ->and(Leaderboard::generate()->first()->id)->toEqual($userWithPoints->id);
+    $entries = Leaderboard::generate();
+
+    expect($entries)->toHaveCount(count: 1)
+        ->and($entries->first()->user->id)->toEqual($userWithPoints->id);
 });


### PR DESCRIPTION
## What this changes

The Leaderboard is no longer hardwired to experience points. It now ranks users by a **metric**, with XP as the default, and returns `LeaderboardEntry` objects instead of bare `User` models.

```php
$entries = Leaderboard::generate(); // still XP, descending — same ordering as v2

foreach ($entries as $entry) {
    $entry->user;  // the User model (Experience eager-loaded)
    $entry->score; // the user's score on this metric
}
```

### Choosing a metric

`by()` accepts a registry key, a class-string, or a metric instance:

```php
Leaderboard::by('xp')->generate();
Leaderboard::by(MyCustomMetric::class)->generate();
Leaderboard::by(new MyCustomMetric())->generate();
```

Metrics live in config under `level-up.leaderboard.metrics`; the default is `level-up.leaderboard.default_metric`. Register your own by implementing `LevelUp\Experience\Contracts\RankingMetric` — a stable `key()`, a `label()`, an `enabled()` check, a `constrain()` scoping the user query to eligible users, and a `scoreExpression()` subquery yielding one numeric score per user.

### Failure behavior

- Unknown metric key → `MetricNotFoundException`
- Metric whose underlying package feature is disabled → `MetricDisabledException` (never a silently empty board)

`forTier()`, `paginate:`, and `limit:` all work unchanged on the new pipeline.

## ⚠️ Breaking change (v3)

`Leaderboard::generate()` now returns a collection (or paginator) of `LeaderboardEntry` objects, not `User` models. Migrate by reading `$entry->user` and `$entry->score`; a sorted user list is `$entries->map(fn ($e) => $e->user)`.

## Notes

- This is the foundation slice of the v3 leaderboard plan — ranks, periods, and further metrics build on this contract in follow-up PRs.
- 100% line + type coverage maintained; PHPStan level 5 clean.

Closes #147