### PR TITLE
feat(v3): rank numbers, ties, rankOf() and around() for leaderboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -561,7 +561,7 @@ public int $amount,
 
 ## 📈 Leaderboard
 
-The package includes a metric-driven leaderboard. A leaderboard ranks users by a **metric** — experience points by default — and returns `LeaderboardEntry` objects exposing the `user` and their `score`.
+The package includes a metric-driven leaderboard. A leaderboard ranks users by a **metric** — experience points by default — and returns `LeaderboardEntry` objects exposing the `user`, their `score`, and their `rank`.
 
 ```php
 $entries = Leaderboard::generate();
@@ -569,10 +569,34 @@ $entries = Leaderboard::generate();
 foreach ($entries as $entry) {
     $entry->user;  // the User model (with Experience eager-loaded)
     $entry->score; // the user's score on this metric
+    $entry->rank;  // the user's position on the board (1 is first)
 }
 ```
 
-Pass `paginate: true` for a paginator of entries, or `limit:` to cap the result count.
+Pass `paginate: true` for a paginator of entries, or `limit:` to cap the result count. Ranks are always board-wide — entry 16 on page 2 still carries rank 16.
+
+### Ranks and ties
+
+Ranks use competition semantics: users with equal scores share a rank, and the next rank is skipped — two users tied for first are both rank 1, and the next user is rank 3. Tied rows are ordered deterministically (score descending, then user key ascending) so pagination boundaries stay stable between requests.
+
+Ranks are computed in the database with SQL window functions, so the leaderboard requires a database that supports them: SQLite 3.25+, MySQL 8+ / MariaDB 10.2+, or PostgreSQL.
+
+### A user's rank
+
+Ask for a single user's exact rank with `rankOf()`, or fetch the slice of the board around them with `around()`:
+
+```php
+Leaderboard::rankOf(user: $user); // 4 — or null if the user isn't on the board
+
+Leaderboard::around(user: $user, range: 2); // up to 2 entries above + the user + up to 2 below
+```
+
+`rankOf()` returns `null` — and `around()` returns an empty collection — when the user is absent from the board (no experience record, or excluded by the metric's constraints). `around()` clamps at the edges: for the leader it returns the user plus the `range` entries below, and each entry keeps its board-wide rank. Both compose with `by()`:
+
+```php
+Leaderboard::by('xp')->rankOf(user: $user);
+Leaderboard::by(MyCustomMetric::class)->around(user: $user, range: 3);
+```
 
 ### Choosing a metric
 

--- a/resources/boost/skills/level-up-development/SKILL.md
+++ b/resources/boost/skills/level-up-development/SKILL.md
@@ -14,7 +14,7 @@ Use this skill when working with gamification features — adding experience poi
 - **Achievements** — Unlockable rewards, optionally with progress tracking, optionally gated by tier.
 - **Streaks** — Track consecutive daily activities with freeze support.
 - **Multipliers** — Database-backed point modifiers with scoping, scheduling, and configurable stacking strategies.
-- **Leaderboard** — Rank users by XP, optionally scoped to a tier.
+- **Leaderboard** — Rank users by any metric (XP by default) with competition-style rank numbers, optionally scoped to a tier.
 - **Auditing** — Automatic history of all XP changes, level-ups, and tier changes.
 
 ## Setup
@@ -558,9 +558,11 @@ Leaderboard::generate(limit: 10);              // Top 10
 Leaderboard::by('xp')->generate();              // Explicit metric key
 Leaderboard::by(MyMetric::class)->generate();   // Custom metric (class or instance)
 Leaderboard::forTier('Gold')->generate();       // Gold tier only
+Leaderboard::rankOf(user: $user);               // Exact rank (int), null if absent from the board
+Leaderboard::around(user: $user, range: 2);     // Up to 2 entries above + user + up to 2 below; empty if absent
 ```
 
-Returns `LeaderboardEntry` objects — `$entry->user` (with `experience` eager-loaded) and `$entry->score` — ordered by score descending. Metrics are registered in `level-up.leaderboard.metrics` (custom ones implement `LevelUp\Experience\Contracts\RankingMetric`); unknown keys throw `MetricNotFoundException`, disabled-feature metrics throw `MetricDisabledException`.
+Returns `LeaderboardEntry` objects — `$entry->user` (with `experience` eager-loaded), `$entry->score`, and `$entry->rank` — ordered by score descending, then user key ascending. Ranks use competition semantics (tied scores share a rank; the next rank is skipped: 1, 1, 3) and are board-wide even when limiting or paginating. `rankOf()` and `around()` compose with `by()`. Ranks are computed with SQL window functions (requires SQLite 3.25+, MySQL 8+, or PostgreSQL). Metrics are registered in `level-up.leaderboard.metrics` (custom ones implement `LevelUp\Experience\Contracts\RankingMetric`); unknown keys throw `MetricNotFoundException`, disabled-feature metrics throw `MetricDisabledException`.
 
 ## Auditing
 

--- a/src/Services/LeaderboardService.php
+++ b/src/Services/LeaderboardService.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
 use LevelUp\Experience\Contracts\RankingMetric;
 use LevelUp\Experience\Exceptions\MetricDisabledException;
 use LevelUp\Experience\Exceptions\MetricNotFoundException;
@@ -48,36 +49,108 @@ class LeaderboardService
 
     public function generate(bool $paginate = false, ?int $limit = null): Collection|LengthAwarePaginator
     {
+        [$metric, $tier] = $this->consumeContext();
+
+        $query = $this->rankedQuery(metric: $metric, tier: $tier)->take(value: $limit);
+
+        return $paginate
+            ? $query->paginate()->through(callback: fn (Model $user): LeaderboardEntry => $this->toEntry($user))
+            : $query->get()->map(callback: fn (Model $user): LeaderboardEntry => $this->toEntry($user));
+    }
+
+    public function rankOf(Model $user): ?int
+    {
+        [$metric, $tier] = $this->consumeContext();
+
+        $rank = DB::query()
+            ->fromSub(query: $this->rankedQuery(metric: $metric, tier: $tier), as: 'ranked')
+            ->where(column: $user->getKeyName(), operator: '=', value: $user->getKey())
+            ->value(column: 'rank');
+
+        return $rank === null ? null : (int) $rank;
+    }
+
+    public function around(Model $user, int $range): Collection
+    {
+        [$metric, $tier] = $this->consumeContext();
+
+        $ranked = $this->rankedQuery(metric: $metric, tier: $tier);
+        $grammar = $ranked->getQuery()->getGrammar();
+
+        $positioned = (clone $ranked)->selectRaw(expression: sprintf(
+            'ROW_NUMBER() OVER (ORDER BY %s DESC, %s ASC) AS %s',
+            $grammar->wrap(value: 'score'),
+            $grammar->wrap(value: $user->getKeyName()),
+            $grammar->wrap(value: 'position'),
+        ));
+
+        $position = DB::query()
+            ->fromSub(query: $positioned, as: 'positioned')
+            ->where(column: $user->getKeyName(), operator: '=', value: $user->getKey())
+            ->value(column: 'position');
+
+        if ($position === null) {
+            return new Collection();
+        }
+
+        $offset = max(0, (int) $position - 1 - $range);
+
+        return $ranked
+            ->skip(value: $offset)
+            ->take(value: (int) $position + $range - $offset)
+            ->get()
+            ->map(callback: fn (Model $user): LeaderboardEntry => $this->toEntry($user))
+            ->toBase();
+    }
+
+    /**
+     * @return array{0: RankingMetric, 1: ?Tier}
+     */
+    private function consumeContext(): array
+    {
         [$tier, $this->tier] = [$this->tier, null];
         [$metric, $this->metric] = [$this->metric ?? $this->defaultMetric(), null];
 
         throw_unless($metric->enabled(), exception: MetricDisabledException::forMetric($metric));
 
-        $users = $this->userModel::query()
+        return [$metric, $tier];
+    }
+
+    private function rankedQuery(RankingMetric $metric, ?Tier $tier): Builder
+    {
+        $scored = $this->userModel::query()
             ->select(columns: config(key: 'level-up.user.users_table').'.*')
             ->selectSub(query: $metric->scoreExpression(), as: 'score')
-            ->with(relations: ['experience'])
             ->tap(callback: fn (Builder $query): Builder => $metric->constrain($query))
             ->when($tier instanceof Tier, fn (Builder $query): Builder => $query->whereHas(
                 'experience',
                 fn (Builder $query): Builder => $query->where(column: 'tier_id', operator: '=', value: $tier->id),
-            ))
-            ->orderByDesc(column: 'score')
-            ->take(value: $limit)
-            ->when($paginate, fn (Builder $query) => $query->paginate(), fn (Builder $query) => $query->get());
+            ));
 
-        return $users instanceof LengthAwarePaginator
-            ? $users->through(callback: fn (Model $user): LeaderboardEntry => $this->toEntry($user))
-            : $users->map(callback: fn (Model $user): LeaderboardEntry => $this->toEntry($user));
+        $grammar = $scored->getQuery()->getGrammar();
+        $keyName = $scored->getModel()->getKeyName();
+
+        return $this->userModel::query()
+            ->fromSub(query: $scored, as: 'board')
+            ->select(columns: 'board.*')
+            ->selectRaw(expression: sprintf(
+                'RANK() OVER (ORDER BY %s DESC) AS %s',
+                $grammar->wrap(value: 'score'),
+                $grammar->wrap(value: 'rank'),
+            ))
+            ->with(relations: ['experience'])
+            ->orderByDesc(column: 'score')
+            ->orderBy(column: $keyName);
     }
 
     private function toEntry(Model $user): LeaderboardEntry
     {
         $score = $user->getAttribute(key: 'score') + 0;
+        $rank = (int) $user->getAttribute(key: 'rank');
 
-        unset($user->score);
+        unset($user->score, $user->rank);
 
-        return new LeaderboardEntry(user: $user, score: $score);
+        return new LeaderboardEntry(user: $user, score: $score, rank: $rank);
     }
 
     private function defaultMetric(): RankingMetric

--- a/src/Support/LeaderboardEntry.php
+++ b/src/Support/LeaderboardEntry.php
@@ -11,5 +11,6 @@ final readonly class LeaderboardEntry
     public function __construct(
         public Model $user,
         public int|float $score,
+        public int $rank,
     ) {}
 }

--- a/tests/Concerns/HasTiersIntegrationTest.php
+++ b/tests/Concerns/HasTiersIntegrationTest.php
@@ -106,3 +106,18 @@ test(description: 'leaderboard can be filtered by tier', closure: function (): v
     expect($silverLeaderboard)->toHaveCount(count: 1)
         ->and($silverLeaderboard->first()->user->id)->toBe(expected: $this->user->id);
 });
+
+test(description: 'a user outside a tier filter is absent from rankOf and around', closure: function (): void {
+    $this->user->addPoints(amount: 550);
+
+    $bronzeUser = User::query()->create([
+        'name' => 'Other User',
+        'email' => 'other@test.com',
+        'password' => bcrypt('password'),
+    ]);
+    $bronzeUser->addPoints(amount: 100);
+
+    expect(resolve('leaderboard')->forTier('Silver')->rankOf(user: $bronzeUser))->toBeNull()
+        ->and(resolve('leaderboard')->forTier('Silver')->around(user: $bronzeUser, range: 1))->toBeEmpty()
+        ->and(resolve('leaderboard')->forTier('Silver')->rankOf(user: $this->user))->toBe(expected: 1);
+});

--- a/tests/Services/LeaderboardServiceTest.php
+++ b/tests/Services/LeaderboardServiceTest.php
@@ -108,6 +108,150 @@ it(description: 'limits the number of leaderboard entries', closure: function ()
         ->toBe([198, 123]);
 });
 
+it(description: 'exposes sequential rank numbers on leaderboard entries', closure: function (): void {
+    tap(User::newFactory()->create())->addPoints(44);
+    tap(User::newFactory()->create())->addPoints(123);
+    tap(User::newFactory()->create())->addPoints(198);
+
+    $entries = Leaderboard::generate();
+
+    expect($entries->map(fn (LeaderboardEntry $entry): int => $entry->rank)->toArray())
+        ->toBe([1, 2, 3]);
+});
+
+it(description: 'shares a rank between tied scores and skips the next rank', closure: function (): void {
+    tap(User::newFactory()->create())->addPoints(200);
+    tap(User::newFactory()->create())->addPoints(200);
+    tap(User::newFactory()->create())->addPoints(100);
+
+    $entries = Leaderboard::generate();
+
+    expect($entries->map(fn (LeaderboardEntry $entry): int => $entry->rank)->toArray())
+        ->toBe([1, 1, 3]);
+});
+
+it(description: 'orders tied rows deterministically by user key ascending', closure: function (): void {
+    $third = tap(User::newFactory()->create())->addPoints(100);
+    $first = tap(User::newFactory()->create())->addPoints(200);
+    $second = tap(User::newFactory()->create())->addPoints(200);
+
+    $entries = Leaderboard::generate();
+
+    expect($entries->map(fn (LeaderboardEntry $entry): mixed => $entry->user->id)->toArray())
+        ->toBe([$first->id, $second->id, $third->id]);
+});
+
+it(description: 'returns the exact rank of a user, sharing ranks between ties', closure: function (): void {
+    $tiedOne = tap(User::newFactory()->create())->addPoints(200);
+    $tiedTwo = tap(User::newFactory()->create())->addPoints(200);
+    $third = tap(User::newFactory()->create())->addPoints(100);
+
+    expect(Leaderboard::rankOf(user: $tiedOne))->toBe(expected: 1)
+        ->and(Leaderboard::rankOf(user: $tiedTwo))->toBe(expected: 1)
+        ->and(Leaderboard::rankOf(user: $third))->toBe(expected: 3);
+});
+
+it(description: 'returns null from rankOf for a user absent from the board', closure: function (): void {
+    tap(User::newFactory()->create())->addPoints(100);
+
+    expect(Leaderboard::rankOf(user: $this->user))->toBeNull();
+});
+
+it(description: 'returns the rank of a user on an explicitly selected metric', closure: function (): void {
+    tap(User::newFactory()->create())->addPoints(999);
+    tap(User::newFactory()->create())->addPoints(1);
+
+    expect(Leaderboard::by(metric: UserIdMetric::class)->rankOf(user: $this->user))->toBe(expected: 3);
+});
+
+it(description: 'returns the entries around a user with their board-wide ranks', closure: function (): void {
+    $users = collect(value: [500, 400, 300, 200, 100])
+        ->map(fn (int $points): User => tap(User::newFactory()->create())->addPoints($points));
+
+    $entries = Leaderboard::around(user: $users[2], range: 1);
+
+    expect($entries)->toHaveCount(count: 3)
+        ->and($entries->map(fn (LeaderboardEntry $entry): int => $entry->score)->toArray())
+        ->toBe([400, 300, 200])
+        ->and($entries->map(fn (LeaderboardEntry $entry): int => $entry->rank)->toArray())
+        ->toBe([2, 3, 4])
+        ->and($entries[1]->user->id)->toEqual($users[2]->id);
+});
+
+it(description: 'clamps the around window at the top of the board', closure: function (): void {
+    $leader = tap(User::newFactory()->create())->addPoints(500);
+    tap(User::newFactory()->create())->addPoints(400);
+    tap(User::newFactory()->create())->addPoints(300);
+    tap(User::newFactory()->create())->addPoints(200);
+
+    $entries = Leaderboard::around(user: $leader, range: 2);
+
+    expect($entries)->toHaveCount(count: 3)
+        ->and($entries->first()->user->id)->toEqual($leader->id)
+        ->and($entries->map(fn (LeaderboardEntry $entry): int => $entry->rank)->toArray())
+        ->toBe([1, 2, 3]);
+});
+
+it(description: 'clamps the around window at the bottom of the board', closure: function (): void {
+    tap(User::newFactory()->create())->addPoints(500);
+    tap(User::newFactory()->create())->addPoints(400);
+    tap(User::newFactory()->create())->addPoints(300);
+    $last = tap(User::newFactory()->create())->addPoints(200);
+
+    $entries = Leaderboard::around(user: $last, range: 2);
+
+    expect($entries)->toHaveCount(count: 3)
+        ->and($entries->last()->user->id)->toEqual($last->id)
+        ->and($entries->map(fn (LeaderboardEntry $entry): int => $entry->rank)->toArray())
+        ->toBe([2, 3, 4]);
+});
+
+it(description: 'returns an empty collection from around for a user absent from the board', closure: function (): void {
+    tap(User::newFactory()->create())->addPoints(100);
+
+    $entries = Leaderboard::around(user: $this->user, range: 2);
+
+    expect($entries)->toBeInstanceOf(class: Illuminate\Support\Collection::class)
+        ->and($entries)->toBeEmpty();
+});
+
+it(description: 'returns the entries around a user on an explicitly selected metric', closure: function (): void {
+    tap(User::newFactory()->create())->addPoints(999);
+    tap(User::newFactory()->create())->addPoints(1);
+
+    $entries = Leaderboard::by(metric: UserIdMetric::class)->around(user: $this->user, range: 1);
+
+    expect($entries)->toHaveCount(count: 2)
+        ->and($entries->map(fn (LeaderboardEntry $entry): int => $entry->rank)->toArray())
+        ->toBe([2, 3])
+        ->and($entries->last()->user->id)->toEqual($this->user->id);
+});
+
+it(description: 'keeps board-wide ranks when limiting entries', closure: function (): void {
+    tap(User::newFactory()->create())->addPoints(200);
+    tap(User::newFactory()->create())->addPoints(200);
+    tap(User::newFactory()->create())->addPoints(100);
+
+    $entries = Leaderboard::generate(limit: 2);
+
+    expect($entries->map(fn (LeaderboardEntry $entry): int => $entry->rank)->toArray())
+        ->toBe([1, 1]);
+});
+
+it(description: 'keeps board-wide ranks on later pages of a paginated leaderboard', closure: function (): void {
+    foreach (range(start: 1, end: 16) as $points) {
+        tap(User::newFactory()->create())->addPoints($points * 10);
+    }
+
+    Illuminate\Pagination\Paginator::currentPageResolver(resolver: fn (): int => 2);
+
+    $paginated = Leaderboard::generate(paginate: true);
+
+    expect($paginated->total())->toBe(expected: 16)
+        ->and($paginated->items())->toHaveCount(count: 1)
+        ->and($paginated->items()[0]->rank)->toBe(expected: 16);
+});
+
 it(description: 'exposes a stable key and label on the experience metric', closure: function (): void {
     $metric = new ExperienceMetric();
 


### PR DESCRIPTION
Leaderboard entries now carry a real rank number, and you can ask for a single user's rank or the slice of the board around them.

## Rank numbers on every entry

`LeaderboardEntry` now exposes `rank` alongside `user` and `score`:

```php
foreach (Leaderboard::generate() as $entry) {
    $entry->rank;  // 1 is first place
    $entry->score;
    $entry->user;
}
```

Ranks use competition semantics — users with equal scores share a rank, and the next rank is skipped (1, 1, 3). Tied rows are ordered deterministically (score descending, then user key ascending), so pagination boundaries stay stable between requests. Ranks are board-wide even when limiting or paginating: entry 16 on page 2 is still rank 16.

## rankOf() — a user's exact rank

```php
Leaderboard::rankOf(user: $user); // 4 — or null if the user isn't on the board
```

Returns `null` when the user is absent from the board: no experience record, excluded by the metric's constraints, or outside a `forTier()` filter.

## around() — the board near a user

```php
Leaderboard::around(user: $user, range: 2); // up to 2 entries above + the user + up to 2 below
```

Clamps at the edges (the leader gets themselves plus `range` entries below), each entry keeps its board-wide rank, and an absent user yields an empty collection.

Both compose with any metric and tier filter:

```php
Leaderboard::by(MyCustomMetric::class)->rankOf(user: $user);
Leaderboard::forTier('Gold')->around(user: $user, range: 3);
```

## Database support

Ranks are computed in the database with ANSI SQL window functions (`RANK() OVER`, `ROW_NUMBER() OVER`) — the package's first deliberate raw SQL, since Laravel's builder has no fluent window-function API. Works on SQLite 3.25+, MySQL 8+ / MariaDB 10.2+, and PostgreSQL.

## Breaking changes

- `LeaderboardEntry`'s constructor gains a required `rank` parameter. `LeaderboardEntry` is new in unreleased v3, so this only affects code written against the v3 development branch.

---

Stacked on #160 (`feat/v3-leaderboard-metric-contract`) — merge that first.

Closes #148