### PR TITLE
feat(v3): level and streak leaderboard metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -610,6 +610,34 @@ Leaderboard::by(new MyCustomMetric())->generate();
 
 An unknown key throws `MetricNotFoundException`; a metric whose underlying feature is disabled throws `MetricDisabledException` rather than returning an empty board.
 
+### Built-in metrics
+
+Three metrics ship with the package:
+
+| Key | Ranks by |
+| --- | --- |
+| `xp` | Experience points (the default) |
+| `level` | Current level |
+| `streak` | Current streak count for an Activity |
+
+`level` ranks users by their current level number — users on the same level share a rank:
+
+```php
+Leaderboard::by('level')->generate();
+```
+
+`streak` ranks users by their current streak count for one Activity, so it needs to know which one. Construct the metric with the Activity and pass the instance:
+
+```php
+use LevelUp\Experience\Metrics\StreakMetric;
+
+Leaderboard::by(new StreakMetric(activity: $activity))->generate();
+```
+
+Generating a streak board without an Activity — for example via the bare registry key, `by('streak')` — throws `MetricRequiresActivityException`.
+
+Both are **state metrics**: they rank by a current snapshot rather than an accumulation. Users without the relevant record are absent from the board — no level (no experience record) means no entry on the level board; no streak for the given Activity means no entry on that streak board.
+
 ### Custom metrics
 
 Rank by anything you can express as a SQL score: implement `LevelUp\Experience\Contracts\RankingMetric` — a stable `key()`, a `label()`, an `enabled()` check, a `constrain()` that scopes the user query to eligible users, and a `scoreExpression()` subquery yielding one numeric score per user — then register the class in `level-up.leaderboard.metrics`.

--- a/README.md
+++ b/README.md
@@ -561,7 +561,7 @@ public int $amount,
 
 ## 📈 Leaderboard
 
-The package includes a metric-driven leaderboard. A leaderboard ranks users by a **metric** — experience points by default — and returns `LeaderboardEntry` objects exposing the `user` and their `score`.
+The package includes a metric-driven leaderboard. A leaderboard ranks users by a **metric** — experience points by default — and returns `LeaderboardEntry` objects exposing the `user`, their `score`, and their `rank`.
 
 ```php
 $entries = Leaderboard::generate();
@@ -569,10 +569,34 @@ $entries = Leaderboard::generate();
 foreach ($entries as $entry) {
     $entry->user;  // the User model (with Experience eager-loaded)
     $entry->score; // the user's score on this metric
+    $entry->rank;  // the user's position on the board (1 is first)
 }
 ```
 
-Pass `paginate: true` for a paginator of entries, or `limit:` to cap the result count.
+Pass `paginate: true` for a paginator of entries, or `limit:` to cap the result count. Ranks are always board-wide — entry 16 on page 2 still carries rank 16.
+
+### Ranks and ties
+
+Ranks use competition semantics: users with equal scores share a rank, and the next rank is skipped — two users tied for first are both rank 1, and the next user is rank 3. Tied rows are ordered deterministically (score descending, then user key ascending) so pagination boundaries stay stable between requests.
+
+Ranks are computed in the database with SQL window functions, so the leaderboard requires a database that supports them: SQLite 3.25+, MySQL 8+ / MariaDB 10.2+, or PostgreSQL.
+
+### A user's rank
+
+Ask for a single user's exact rank with `rankOf()`, or fetch the slice of the board around them with `around()`:
+
+```php
+Leaderboard::rankOf(user: $user); // 4 — or null if the user isn't on the board
+
+Leaderboard::around(user: $user, range: 2); // up to 2 entries above + the user + up to 2 below
+```
+
+`rankOf()` returns `null` — and `around()` returns an empty collection — when the user is absent from the board (no experience record, or excluded by the metric's constraints). `around()` clamps at the edges: for the leader it returns the user plus the `range` entries below, and each entry keeps its board-wide rank. Both compose with `by()`:
+
+```php
+Leaderboard::by('xp')->rankOf(user: $user);
+Leaderboard::by(MyCustomMetric::class)->around(user: $user, range: 3);
+```
 
 ### Choosing a metric
 

--- a/config/level-up.php
+++ b/config/level-up.php
@@ -114,6 +114,8 @@ return [
         'default_metric' => 'xp',
         'metrics' => [
             'xp' => LevelUp\Experience\Metrics\ExperienceMetric::class,
+            'level' => LevelUp\Experience\Metrics\LevelMetric::class,
+            'streak' => LevelUp\Experience\Metrics\StreakMetric::class,
         ],
     ],
 

--- a/database/factories/ActivityFactory.php
+++ b/database/factories/ActivityFactory.php
@@ -17,7 +17,7 @@ class ActivityFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => fake()->word(),
+            'name' => fake()->unique()->word(),
             'description' => fake()->sentence(),
         ];
     }

--- a/resources/boost/skills/level-up-development/SKILL.md
+++ b/resources/boost/skills/level-up-development/SKILL.md
@@ -551,11 +551,14 @@ Reference it in the condition: `['type' => 'custom', 'class' => HasVerifiedEmail
 
 ```php
 use LevelUp\Experience\Facades\Leaderboard;
+use LevelUp\Experience\Metrics\StreakMetric;
 
 Leaderboard::generate();                        // Default metric (XP), score descending
 Leaderboard::generate(paginate: true);          // Paginated
 Leaderboard::generate(limit: 10);              // Top 10
 Leaderboard::by('xp')->generate();              // Explicit metric key
+Leaderboard::by('level')->generate();           // Rank by current level
+Leaderboard::by(new StreakMetric(activity: $activity))->generate(); // Rank by current streak count for an Activity
 Leaderboard::by(MyMetric::class)->generate();   // Custom metric (class or instance)
 Leaderboard::forTier('Gold')->generate();       // Gold tier only
 Leaderboard::rankOf(user: $user);               // Exact rank (int), null if absent from the board
@@ -563,6 +566,8 @@ Leaderboard::around(user: $user, range: 2);     // Up to 2 entries above + user 
 ```
 
 Returns `LeaderboardEntry` objects — `$entry->user` (with `experience` eager-loaded), `$entry->score`, and `$entry->rank` — ordered by score descending, then user key ascending. Ranks use competition semantics (tied scores share a rank; the next rank is skipped: 1, 1, 3) and are board-wide even when limiting or paginating. `rankOf()` and `around()` compose with `by()`. Ranks are computed with SQL window functions (requires SQLite 3.25+, MySQL 8+, or PostgreSQL). Metrics are registered in `level-up.leaderboard.metrics` (custom ones implement `LevelUp\Experience\Contracts\RankingMetric`); unknown keys throw `MetricNotFoundException`, disabled-feature metrics throw `MetricDisabledException`.
+
+Built-in metrics: `xp` (experience points, the default), `level` (current level), and `streak` (current streak count for an Activity). `level` and `streak` are state metrics — they rank by a current snapshot, and users without the relevant record are absent from the board. The streak metric requires an Activity: construct the instance (`new StreakMetric(activity: $activity)`); using the bare `streak` registry key without one throws `MetricRequiresActivityException`.
 
 ## Auditing
 

--- a/resources/boost/skills/level-up-development/SKILL.md
+++ b/resources/boost/skills/level-up-development/SKILL.md
@@ -14,7 +14,7 @@ Use this skill when working with gamification features — adding experience poi
 - **Achievements** — Unlockable rewards, optionally with progress tracking, optionally gated by tier.
 - **Streaks** — Track consecutive daily activities with freeze support.
 - **Multipliers** — Database-backed point modifiers with scoping, scheduling, and configurable stacking strategies.
-- **Leaderboard** — Rank users by XP, optionally scoped to a tier.
+- **Leaderboard** — Rank users by any metric (XP by default) with competition-style rank numbers, optionally scoped to a tier.
 - **Auditing** — Automatic history of all XP changes, level-ups, and tier changes.
 
 ## Setup
@@ -558,9 +558,11 @@ Leaderboard::generate(limit: 10);              // Top 10
 Leaderboard::by('xp')->generate();              // Explicit metric key
 Leaderboard::by(MyMetric::class)->generate();   // Custom metric (class or instance)
 Leaderboard::forTier('Gold')->generate();       // Gold tier only
+Leaderboard::rankOf(user: $user);               // Exact rank (int), null if absent from the board
+Leaderboard::around(user: $user, range: 2);     // Up to 2 entries above + user + up to 2 below; empty if absent
 ```
 
-Returns `LeaderboardEntry` objects — `$entry->user` (with `experience` eager-loaded) and `$entry->score` — ordered by score descending. Metrics are registered in `level-up.leaderboard.metrics` (custom ones implement `LevelUp\Experience\Contracts\RankingMetric`); unknown keys throw `MetricNotFoundException`, disabled-feature metrics throw `MetricDisabledException`.
+Returns `LeaderboardEntry` objects — `$entry->user` (with `experience` eager-loaded), `$entry->score`, and `$entry->rank` — ordered by score descending, then user key ascending. Ranks use competition semantics (tied scores share a rank; the next rank is skipped: 1, 1, 3) and are board-wide even when limiting or paginating. `rankOf()` and `around()` compose with `by()`. Ranks are computed with SQL window functions (requires SQLite 3.25+, MySQL 8+, or PostgreSQL). Metrics are registered in `level-up.leaderboard.metrics` (custom ones implement `LevelUp\Experience\Contracts\RankingMetric`); unknown keys throw `MetricNotFoundException`, disabled-feature metrics throw `MetricDisabledException`.
 
 ## Auditing
 

--- a/src/Exceptions/MetricRequiresActivityException.php
+++ b/src/Exceptions/MetricRequiresActivityException.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LevelUp\Experience\Exceptions;
+
+use Exception;
+use LevelUp\Experience\Contracts\RankingMetric;
+
+final class MetricRequiresActivityException extends Exception
+{
+    public static function forMetric(RankingMetric $metric): self
+    {
+        return new self(message: "The [{$metric->key()}] leaderboard metric requires an Activity. Construct it with one and pass the instance to Leaderboard::by().");
+    }
+}

--- a/src/Metrics/LevelMetric.php
+++ b/src/Metrics/LevelMetric.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LevelUp\Experience\Metrics;
+
+use Illuminate\Contracts\Database\Query\Builder;
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
+use LevelUp\Experience\Contracts\RankingMetric;
+
+class LevelMetric implements RankingMetric
+{
+    public function key(): string
+    {
+        return 'level';
+    }
+
+    public function label(): string
+    {
+        return 'Level';
+    }
+
+    public function enabled(): bool
+    {
+        return true;
+    }
+
+    public function constrain(EloquentBuilder $query): EloquentBuilder
+    {
+        return $query->whereHas(
+            relation: 'experience',
+            callback: fn (EloquentBuilder $query): EloquentBuilder => $query->whereNotNull(columns: 'level_id'),
+        );
+    }
+
+    public function scoreExpression(): Builder
+    {
+        $experienceModel = config(key: 'level-up.models.experience');
+        $levelModel = config(key: 'level-up.models.level');
+
+        $experiencesTable = (new $experienceModel())->getTable();
+        $levelsTable = (new $levelModel())->getTable();
+
+        return $experienceModel::query()
+            ->select(columns: $levelsTable.'.level')
+            ->join(
+                table: $levelsTable,
+                first: $experiencesTable.'.level_id',
+                operator: '=',
+                second: $levelsTable.'.id',
+            )
+            ->whereColumn(
+                first: $experiencesTable.'.'.config(key: 'level-up.user.foreign_key'),
+                operator: '=',
+                second: config(key: 'level-up.user.users_table').'.id',
+            )
+            ->take(value: 1)
+            ->toBase();
+    }
+}

--- a/src/Metrics/StreakMetric.php
+++ b/src/Metrics/StreakMetric.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LevelUp\Experience\Metrics;
+
+use Illuminate\Contracts\Database\Query\Builder;
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
+use LevelUp\Experience\Contracts\RankingMetric;
+use LevelUp\Experience\Exceptions\MetricRequiresActivityException;
+use LevelUp\Experience\Models\Activity;
+
+class StreakMetric implements RankingMetric
+{
+    public function __construct(private readonly ?Activity $activity = null) {}
+
+    public function key(): string
+    {
+        return 'streak';
+    }
+
+    public function label(): string
+    {
+        return 'Streak';
+    }
+
+    public function enabled(): bool
+    {
+        return true;
+    }
+
+    public function constrain(EloquentBuilder $query): EloquentBuilder
+    {
+        return $query->whereHas(
+            relation: 'streaks',
+            callback: fn (EloquentBuilder $query): EloquentBuilder => $query->where(
+                column: 'activity_id',
+                operator: '=',
+                value: $this->activity()->id,
+            ),
+        );
+    }
+
+    public function scoreExpression(): Builder
+    {
+        $streakModel = config(key: 'level-up.models.streak');
+
+        return $streakModel::query()
+            ->select(columns: 'count')
+            ->where(column: 'activity_id', operator: '=', value: $this->activity()->id)
+            ->whereColumn(
+                first: config(key: 'level-up.user.foreign_key'),
+                operator: '=',
+                second: config(key: 'level-up.user.users_table').'.id',
+            )
+            ->take(value: 1)
+            ->toBase();
+    }
+
+    private function activity(): Activity
+    {
+        throw_unless($this->activity instanceof Activity, exception: MetricRequiresActivityException::forMetric($this));
+
+        return $this->activity;
+    }
+}

--- a/src/Services/LeaderboardService.php
+++ b/src/Services/LeaderboardService.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
 use LevelUp\Experience\Contracts\RankingMetric;
 use LevelUp\Experience\Exceptions\MetricDisabledException;
 use LevelUp\Experience\Exceptions\MetricNotFoundException;
@@ -48,36 +49,108 @@ class LeaderboardService
 
     public function generate(bool $paginate = false, ?int $limit = null): Collection|LengthAwarePaginator
     {
+        [$metric, $tier] = $this->consumeContext();
+
+        $query = $this->rankedQuery(metric: $metric, tier: $tier)->take(value: $limit);
+
+        return $paginate
+            ? $query->paginate()->through(callback: fn (Model $user): LeaderboardEntry => $this->toEntry($user))
+            : $query->get()->map(callback: fn (Model $user): LeaderboardEntry => $this->toEntry($user));
+    }
+
+    public function rankOf(Model $user): ?int
+    {
+        [$metric, $tier] = $this->consumeContext();
+
+        $rank = DB::query()
+            ->fromSub(query: $this->rankedQuery(metric: $metric, tier: $tier), as: 'ranked')
+            ->where(column: $user->getKeyName(), operator: '=', value: $user->getKey())
+            ->value(column: 'rank');
+
+        return $rank === null ? null : (int) $rank;
+    }
+
+    public function around(Model $user, int $range): Collection
+    {
+        [$metric, $tier] = $this->consumeContext();
+
+        $ranked = $this->rankedQuery(metric: $metric, tier: $tier);
+        $grammar = $ranked->getQuery()->getGrammar();
+
+        $positioned = (clone $ranked)->selectRaw(expression: sprintf(
+            'ROW_NUMBER() OVER (ORDER BY %s DESC, %s ASC) AS %s',
+            $grammar->wrap(value: 'score'),
+            $grammar->wrap(value: $user->getKeyName()),
+            $grammar->wrap(value: 'position'),
+        ));
+
+        $position = DB::query()
+            ->fromSub(query: $positioned, as: 'positioned')
+            ->where(column: $user->getKeyName(), operator: '=', value: $user->getKey())
+            ->value(column: 'position');
+
+        if ($position === null) {
+            return new Collection();
+        }
+
+        $offset = max(0, (int) $position - 1 - $range);
+
+        return $ranked
+            ->skip(value: $offset)
+            ->take(value: (int) $position + $range - $offset)
+            ->get()
+            ->map(callback: fn (Model $user): LeaderboardEntry => $this->toEntry($user))
+            ->toBase();
+    }
+
+    /**
+     * @return array{0: RankingMetric, 1: ?Tier}
+     */
+    private function consumeContext(): array
+    {
         [$tier, $this->tier] = [$this->tier, null];
         [$metric, $this->metric] = [$this->metric ?? $this->defaultMetric(), null];
 
         throw_unless($metric->enabled(), exception: MetricDisabledException::forMetric($metric));
 
-        $users = $this->userModel::query()
+        return [$metric, $tier];
+    }
+
+    private function rankedQuery(RankingMetric $metric, ?Tier $tier): Builder
+    {
+        $scored = $this->userModel::query()
             ->select(columns: config(key: 'level-up.user.users_table').'.*')
             ->selectSub(query: $metric->scoreExpression(), as: 'score')
-            ->with(relations: ['experience'])
             ->tap(callback: fn (Builder $query): Builder => $metric->constrain($query))
             ->when($tier instanceof Tier, fn (Builder $query): Builder => $query->whereHas(
                 'experience',
                 fn (Builder $query): Builder => $query->where(column: 'tier_id', operator: '=', value: $tier->id),
-            ))
-            ->orderByDesc(column: 'score')
-            ->take(value: $limit)
-            ->when($paginate, fn (Builder $query) => $query->paginate(), fn (Builder $query) => $query->get());
+            ));
 
-        return $users instanceof LengthAwarePaginator
-            ? $users->through(callback: fn (Model $user): LeaderboardEntry => $this->toEntry($user))
-            : $users->map(callback: fn (Model $user): LeaderboardEntry => $this->toEntry($user));
+        $grammar = $scored->getQuery()->getGrammar();
+        $keyName = $scored->getModel()->getKeyName();
+
+        return $this->userModel::query()
+            ->fromSub(query: $scored, as: 'board')
+            ->select(columns: 'board.*')
+            ->selectRaw(expression: sprintf(
+                'RANK() OVER (ORDER BY %s DESC) AS %s',
+                $grammar->wrap(value: 'score'),
+                $grammar->wrap(value: 'rank'),
+            ))
+            ->with(relations: ['experience'])
+            ->orderByDesc(column: 'score')
+            ->orderBy(column: $keyName);
     }
 
     private function toEntry(Model $user): LeaderboardEntry
     {
         $score = $user->getAttribute(key: 'score') + 0;
+        $rank = (int) $user->getAttribute(key: 'rank');
 
-        unset($user->score);
+        unset($user->score, $user->rank);
 
-        return new LeaderboardEntry(user: $user, score: $score);
+        return new LeaderboardEntry(user: $user, score: $score, rank: $rank);
     }
 
     private function defaultMetric(): RankingMetric

--- a/src/Support/LeaderboardEntry.php
+++ b/src/Support/LeaderboardEntry.php
@@ -11,5 +11,6 @@ final readonly class LeaderboardEntry
     public function __construct(
         public Model $user,
         public int|float $score,
+        public int $rank,
     ) {}
 }

--- a/tests/Concerns/HasTiersIntegrationTest.php
+++ b/tests/Concerns/HasTiersIntegrationTest.php
@@ -106,3 +106,18 @@ test(description: 'leaderboard can be filtered by tier', closure: function (): v
     expect($silverLeaderboard)->toHaveCount(count: 1)
         ->and($silverLeaderboard->first()->user->id)->toBe(expected: $this->user->id);
 });
+
+test(description: 'a user outside a tier filter is absent from rankOf and around', closure: function (): void {
+    $this->user->addPoints(amount: 550);
+
+    $bronzeUser = User::query()->create([
+        'name' => 'Other User',
+        'email' => 'other@test.com',
+        'password' => bcrypt('password'),
+    ]);
+    $bronzeUser->addPoints(amount: 100);
+
+    expect(resolve('leaderboard')->forTier('Silver')->rankOf(user: $bronzeUser))->toBeNull()
+        ->and(resolve('leaderboard')->forTier('Silver')->around(user: $bronzeUser, range: 1))->toBeEmpty()
+        ->and(resolve('leaderboard')->forTier('Silver')->rankOf(user: $this->user))->toBe(expected: 1);
+});

--- a/tests/Services/LeaderboardServiceTest.php
+++ b/tests/Services/LeaderboardServiceTest.php
@@ -108,6 +108,150 @@ it(description: 'limits the number of leaderboard entries', closure: function ()
         ->toBe([198, 123]);
 });
 
+it(description: 'exposes sequential rank numbers on leaderboard entries', closure: function (): void {
+    tap(User::newFactory()->create())->addPoints(44);
+    tap(User::newFactory()->create())->addPoints(123);
+    tap(User::newFactory()->create())->addPoints(198);
+
+    $entries = Leaderboard::generate();
+
+    expect($entries->map(fn (LeaderboardEntry $entry): int => $entry->rank)->toArray())
+        ->toBe([1, 2, 3]);
+});
+
+it(description: 'shares a rank between tied scores and skips the next rank', closure: function (): void {
+    tap(User::newFactory()->create())->addPoints(200);
+    tap(User::newFactory()->create())->addPoints(200);
+    tap(User::newFactory()->create())->addPoints(100);
+
+    $entries = Leaderboard::generate();
+
+    expect($entries->map(fn (LeaderboardEntry $entry): int => $entry->rank)->toArray())
+        ->toBe([1, 1, 3]);
+});
+
+it(description: 'orders tied rows deterministically by user key ascending', closure: function (): void {
+    $third = tap(User::newFactory()->create())->addPoints(100);
+    $first = tap(User::newFactory()->create())->addPoints(200);
+    $second = tap(User::newFactory()->create())->addPoints(200);
+
+    $entries = Leaderboard::generate();
+
+    expect($entries->map(fn (LeaderboardEntry $entry): mixed => $entry->user->id)->toArray())
+        ->toBe([$first->id, $second->id, $third->id]);
+});
+
+it(description: 'returns the exact rank of a user, sharing ranks between ties', closure: function (): void {
+    $tiedOne = tap(User::newFactory()->create())->addPoints(200);
+    $tiedTwo = tap(User::newFactory()->create())->addPoints(200);
+    $third = tap(User::newFactory()->create())->addPoints(100);
+
+    expect(Leaderboard::rankOf(user: $tiedOne))->toBe(expected: 1)
+        ->and(Leaderboard::rankOf(user: $tiedTwo))->toBe(expected: 1)
+        ->and(Leaderboard::rankOf(user: $third))->toBe(expected: 3);
+});
+
+it(description: 'returns null from rankOf for a user absent from the board', closure: function (): void {
+    tap(User::newFactory()->create())->addPoints(100);
+
+    expect(Leaderboard::rankOf(user: $this->user))->toBeNull();
+});
+
+it(description: 'returns the rank of a user on an explicitly selected metric', closure: function (): void {
+    tap(User::newFactory()->create())->addPoints(999);
+    tap(User::newFactory()->create())->addPoints(1);
+
+    expect(Leaderboard::by(metric: UserIdMetric::class)->rankOf(user: $this->user))->toBe(expected: 3);
+});
+
+it(description: 'returns the entries around a user with their board-wide ranks', closure: function (): void {
+    $users = collect(value: [500, 400, 300, 200, 100])
+        ->map(fn (int $points): User => tap(User::newFactory()->create())->addPoints($points));
+
+    $entries = Leaderboard::around(user: $users[2], range: 1);
+
+    expect($entries)->toHaveCount(count: 3)
+        ->and($entries->map(fn (LeaderboardEntry $entry): int => $entry->score)->toArray())
+        ->toBe([400, 300, 200])
+        ->and($entries->map(fn (LeaderboardEntry $entry): int => $entry->rank)->toArray())
+        ->toBe([2, 3, 4])
+        ->and($entries[1]->user->id)->toEqual($users[2]->id);
+});
+
+it(description: 'clamps the around window at the top of the board', closure: function (): void {
+    $leader = tap(User::newFactory()->create())->addPoints(500);
+    tap(User::newFactory()->create())->addPoints(400);
+    tap(User::newFactory()->create())->addPoints(300);
+    tap(User::newFactory()->create())->addPoints(200);
+
+    $entries = Leaderboard::around(user: $leader, range: 2);
+
+    expect($entries)->toHaveCount(count: 3)
+        ->and($entries->first()->user->id)->toEqual($leader->id)
+        ->and($entries->map(fn (LeaderboardEntry $entry): int => $entry->rank)->toArray())
+        ->toBe([1, 2, 3]);
+});
+
+it(description: 'clamps the around window at the bottom of the board', closure: function (): void {
+    tap(User::newFactory()->create())->addPoints(500);
+    tap(User::newFactory()->create())->addPoints(400);
+    tap(User::newFactory()->create())->addPoints(300);
+    $last = tap(User::newFactory()->create())->addPoints(200);
+
+    $entries = Leaderboard::around(user: $last, range: 2);
+
+    expect($entries)->toHaveCount(count: 3)
+        ->and($entries->last()->user->id)->toEqual($last->id)
+        ->and($entries->map(fn (LeaderboardEntry $entry): int => $entry->rank)->toArray())
+        ->toBe([2, 3, 4]);
+});
+
+it(description: 'returns an empty collection from around for a user absent from the board', closure: function (): void {
+    tap(User::newFactory()->create())->addPoints(100);
+
+    $entries = Leaderboard::around(user: $this->user, range: 2);
+
+    expect($entries)->toBeInstanceOf(class: Illuminate\Support\Collection::class)
+        ->and($entries)->toBeEmpty();
+});
+
+it(description: 'returns the entries around a user on an explicitly selected metric', closure: function (): void {
+    tap(User::newFactory()->create())->addPoints(999);
+    tap(User::newFactory()->create())->addPoints(1);
+
+    $entries = Leaderboard::by(metric: UserIdMetric::class)->around(user: $this->user, range: 1);
+
+    expect($entries)->toHaveCount(count: 2)
+        ->and($entries->map(fn (LeaderboardEntry $entry): int => $entry->rank)->toArray())
+        ->toBe([2, 3])
+        ->and($entries->last()->user->id)->toEqual($this->user->id);
+});
+
+it(description: 'keeps board-wide ranks when limiting entries', closure: function (): void {
+    tap(User::newFactory()->create())->addPoints(200);
+    tap(User::newFactory()->create())->addPoints(200);
+    tap(User::newFactory()->create())->addPoints(100);
+
+    $entries = Leaderboard::generate(limit: 2);
+
+    expect($entries->map(fn (LeaderboardEntry $entry): int => $entry->rank)->toArray())
+        ->toBe([1, 1]);
+});
+
+it(description: 'keeps board-wide ranks on later pages of a paginated leaderboard', closure: function (): void {
+    foreach (range(start: 1, end: 16) as $points) {
+        tap(User::newFactory()->create())->addPoints($points * 10);
+    }
+
+    Illuminate\Pagination\Paginator::currentPageResolver(resolver: fn (): int => 2);
+
+    $paginated = Leaderboard::generate(paginate: true);
+
+    expect($paginated->total())->toBe(expected: 16)
+        ->and($paginated->items())->toHaveCount(count: 1)
+        ->and($paginated->items()[0]->rank)->toBe(expected: 16);
+});
+
 it(description: 'exposes a stable key and label on the experience metric', closure: function (): void {
     $metric = new ExperienceMetric();
 

--- a/tests/Services/LeaderboardStateMetricsTest.php
+++ b/tests/Services/LeaderboardStateMetricsTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+uses()->group('leaderboard');
+
+use LevelUp\Experience\Exceptions\MetricRequiresActivityException;
+use LevelUp\Experience\Facades\Leaderboard;
+use LevelUp\Experience\Metrics\LevelMetric;
+use LevelUp\Experience\Metrics\StreakMetric;
+use LevelUp\Experience\Models\Activity;
+use LevelUp\Experience\Support\LeaderboardEntry;
+use LevelUp\Experience\Tests\Fixtures\User;
+
+beforeEach(function (): void {
+    config(['level-up.user.model' => User::class]);
+    config(['level-up.multiplier.enabled' => false]);
+});
+
+it(description: 'ranks users by their current level', closure: function (): void {
+    tap(User::newFactory()->create())->addPoints(50);
+    tap(User::newFactory()->create())->addPoints(300);
+    tap(User::newFactory()->create())->addPoints(120);
+
+    $entries = Leaderboard::by(metric: 'level')->generate();
+
+    expect($entries->map(fn (LeaderboardEntry $entry): int => $entry->score)->toArray())
+        ->toBe([3, 2, 1]);
+});
+
+it(description: 'omits users without a level from the level board', closure: function (): void {
+    $levelled = tap(User::newFactory()->create())->addPoints(120);
+
+    $entries = Leaderboard::by(metric: 'level')->generate();
+
+    expect($entries)->toHaveCount(count: 1)
+        ->and($entries->first()->user->id)->toEqual($levelled->id);
+});
+
+it(description: 'shares a rank between users on the same level', closure: function (): void {
+    tap(User::newFactory()->create())->addPoints(300);
+    tap(User::newFactory()->create())->addPoints(120);
+    tap(User::newFactory()->create())->addPoints(150);
+
+    $entries = Leaderboard::by(metric: 'level')->generate();
+
+    expect($entries->map(fn (LeaderboardEntry $entry): int => $entry->rank)->toArray())
+        ->toBe([1, 2, 2]);
+});
+
+it(description: 'ranks users by their current streak count for an activity', closure: function (): void {
+    $activity = Activity::factory()->create();
+
+    User::newFactory()->create()->streaks()->create(['activity_id' => $activity->id, 'count' => 3, 'activity_at' => now()]);
+    User::newFactory()->create()->streaks()->create(['activity_id' => $activity->id, 'count' => 12, 'activity_at' => now()]);
+    User::newFactory()->create()->streaks()->create(['activity_id' => $activity->id, 'count' => 7, 'activity_at' => now()]);
+
+    $entries = Leaderboard::by(metric: new StreakMetric(activity: $activity))->generate();
+
+    expect($entries->map(fn (LeaderboardEntry $entry): int => $entry->score)->toArray())
+        ->toBe([12, 7, 3]);
+});
+
+it(description: 'omits users without a streak for the activity from the streak board', closure: function (): void {
+    $activity = Activity::factory()->create();
+    $otherActivity = Activity::factory()->create();
+
+    $streaker = User::newFactory()->create();
+    $streaker->streaks()->create(['activity_id' => $activity->id, 'count' => 4, 'activity_at' => now()]);
+
+    User::newFactory()->create()->streaks()->create(['activity_id' => $otherActivity->id, 'count' => 9, 'activity_at' => now()]);
+
+    $entries = Leaderboard::by(metric: new StreakMetric(activity: $activity))->generate();
+
+    expect($entries)->toHaveCount(count: 1)
+        ->and($entries->first()->user->id)->toEqual($streaker->id)
+        ->and($entries->first()->score)->toBe(expected: 4);
+});
+
+it(description: 'throws when generating a streak board without an activity', closure: function (): void {
+    Leaderboard::by(metric: 'streak')->generate();
+})->throws(exception: MetricRequiresActivityException::class, exceptionMessage: 'streak');
+
+it(description: 'exposes a stable key and label on the level metric', closure: function (): void {
+    $metric = new LevelMetric();
+
+    expect($metric->key())->toBe(expected: 'level')
+        ->and($metric->label())->toBe(expected: 'Level')
+        ->and($metric->enabled())->toBeTrue();
+});
+
+it(description: 'exposes a stable key and label on the streak metric', closure: function (): void {
+    $metric = new StreakMetric(activity: Activity::factory()->create());
+
+    expect($metric->key())->toBe(expected: 'streak')
+        ->and($metric->label())->toBe(expected: 'Streak')
+        ->and($metric->enabled())->toBeTrue();
+});


### PR DESCRIPTION
Two new built-in leaderboard metrics ship with this PR: `level` and `streak`. Both are **state metrics** — they rank users by a current snapshot rather than an accumulation.

## Rank by current level

```php
Leaderboard::by('level')->generate();
```

Ranks users by their current level number. Users on the same level share a rank (competition semantics, same as every board): two users on level 5 are both rank 1, and the next user is rank 3.

## Rank by current streak

A streak board ranks users by their current streak count for one Activity, so the metric needs to know which one — construct it with the Activity and pass the instance:

```php
use LevelUp\Experience\Metrics\StreakMetric;

Leaderboard::by(new StreakMetric(activity: $activity))->generate();
```

Generating a streak board without an Activity — for example via the bare registry key, `Leaderboard::by('streak')` — throws a new `MetricRequiresActivityException` rather than silently ranking by nothing.

## Absent means absent

Consistent with the XP board: users without the relevant record simply don't appear. No experience record means no entry on the level board; no streak for the given Activity means no entry on that streak board — `rankOf()` returns `null` and `around()` returns an empty collection for them.

Both metrics are registered in the config under `level-up.leaderboard.metrics` (`level`, `streak`), and both compose with everything boards already do: `generate()` (plain, paginated, limited), `rankOf()`, `around()`, and `forTier()`.

### Design note: parameterized metrics

`by()` keeps its existing signature (`string|RankingMetric`). Metrics that need a parameter — like the streak metric's Activity — carry it in their constructor and are passed as instances. The string-key form stays reserved for parameterless resolution, which keeps the metric registry simple and works unchanged for custom metrics.

No breaking changes.

Stacked on #161 (`feat/v3-leaderboard-ranks`); diff shows only this slice once that merges.

Closes #149