### PR TITLE
feat(v3): daily, weekly and monthly leaderboards via Periods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to `level-up` will be documented in this file.
 - **`LevelUp\Experience\Support\UserForeignKey` helper class removed.** Replaced by a `$table->userForeignId()` Blueprint macro that reads the same config and routes to `foreignId()` / `foreignUuid()` / `foreignUlid()`.
 - **Trait method aliasing helpers removed** (cherry-picked from v2.1's revert of PR #123). Host User models with colliding `challenges()` / `streaks()` / `experience()` / `experienceHistory()` methods need to rename or compose into a wrapper model.
 - **`setPoints()` recalculates level and tier.** Previously a raw column write with no side effects; now fires `UserLevelledUp` / `UserTierUpdated` events when the new point total implies a different placement.
+- **`level-up.audit.enabled` now defaults to `true`** (was `false`). Time-windowed leaderboards source their scores from the `experience_audits` ledger, so auditing is on out of the box. Set `AUDIT_POINTS=false` to opt out. See UPGRADE.md.
 - **Excess points cap at the top level instead of throwing.** `addPoints($amount)` where `$amount` exceeds the highest defined level's threshold no longer throws — the user is capped at the highest level.
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -638,13 +638,61 @@ Generating a streak board without an Activity — for example via the bare regis
 
 Both are **state metrics**: they rank by a current snapshot rather than an accumulation. Users without the relevant record are absent from the board — no level (no experience record) means no entry on the level board; no streak for the given Activity means no entry on that streak board.
 
+### Time periods
+
+Scope a board to a bounded time window with `period()` — "top earners this week" instead of "highest totals ever":
+
+```php
+use LevelUp\Experience\Enums\Period;
+
+Leaderboard::period(Period::Day)->generate();   // points earned today
+Leaderboard::period(Period::Week)->generate();  // points earned this week
+Leaderboard::period(Period::Month)->generate(); // points earned this month
+```
+
+Or pick a custom range with `since()` — an open-ended start, or a bounded `[start, until)` window:
+
+```php
+Leaderboard::since(start: now()->subDays(3))->generate();
+
+Leaderboard::since(start: $seasonStart, until: $seasonEnd)->generate();
+```
+
+Periodic boards rank by activity *within* the window, sourced from the `experience_audits` ledger: the windowed score is the sum of points **added minus points removed** in the window. State-change audit rows (`reset`, `level_up`, `tier_up`, `tier_down`) never count. Users with no qualifying audit rows in the window are absent from the board. Everything composes as usual — `rankOf()`, `around()`, ties, `limit:`, `paginate:` all work on a periodic board:
+
+```php
+Leaderboard::period(Period::Week)->rankOf(user: $user);
+Leaderboard::period(Period::Week)->around(user: $user, range: 2);
+```
+
+Periodic boards require auditing (on by default since v3 — see `level-up.audit.enabled`). If you have explicitly disabled auditing, requesting a periodic board throws `MetricRequiresAuditingException` rather than returning a silently empty board. Boards without a period are unaffected: the all-time board keeps reading the cheap `experiences.experience_points` column and never scans the ledger.
+
+Only metrics that implement the `LevelUp\Experience\Contracts\Windowable` interface support periods. The built-in `xp` metric does; `level` and `streak` are state metrics — a current level or streak count isn't "earned within a window" — so selecting a period for them throws `MetricNotWindowableException`.
+
+> [!NOTE]
+> `setPoints()` is an administrative override, not earned activity — it writes no audit record, so it deliberately never moves a periodic board. The all-time board sees the new total immediately.
+
+Week boundaries and timezones are configurable under `level-up.leaderboard`:
+
+```php
+'leaderboard' => [
+    // ...
+    'week_starts_on' => Carbon\CarbonInterface::MONDAY, // 0 (Sunday) – 6 (Saturday)
+    'timezone' => null, // null = the application timezone
+],
+```
+
+`week_starts_on` sets which day `Period::Week` starts on. `timezone` controls the timezone period boundaries (start of day/week/month) are computed in — useful when your app stores UTC but your users' "today" starts at midnight local time.
+
 ### Custom metrics
 
 Rank by anything you can express as a SQL score: implement `LevelUp\Experience\Contracts\RankingMetric` — a stable `key()`, a `label()`, an `enabled()` check, a `constrain()` that scopes the user query to eligible users, and a `scoreExpression()` subquery yielding one numeric score per user — then register the class in `level-up.leaderboard.metrics`.
 
+To support time periods too, also implement `LevelUp\Experience\Contracts\Windowable` — a `windowedScoreExpression($start, $end)` subquery yielding one numeric score per user for activity between the two timestamps (`$end` may be `null` for an open-ended `since()` range).
+
 ## 🔍 Auditing
 
-You can enable an Auditing feature in the config, which keeps a track each time a User gains points, levels up and what level to.
+Auditing keeps track each time a User gains points, levels up and what level to. It is **enabled by default** (since v3) because periodic leaderboards source their scores from the audit ledger — set `AUDIT_POINTS=false` (or `level-up.audit.enabled`) to turn it off if you don't need point history or time-windowed boards.
 
 The `type` and `reason` fields will be populated automatically based on the action taken, but you can overwrite these when adding points to a User
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -86,6 +86,16 @@ Internal trait helpers like `experienceRelation()`, `challengesRelation()`, `str
 - Rename your method to avoid the collision (e.g. `userChallenges()`), or
 - Move the level-up traits onto a separate `UserProfile` / `Gamification` model and compose it onto User (same pattern Spatie's permission package uses).
 
+### Auditing is now enabled by default
+
+**Likelihood Of Impact: Medium** (every install that never published the config or never set `AUDIT_POINTS`).
+
+`level-up.audit.enabled` now defaults to `true` (was `false`). v3's time-windowed leaderboards (`Leaderboard::period(...)` / `since(...)`) compute scores from the `experience_audits` ledger, so auditing is on out of the box — every `addPoints()` / `deductPoints()` call writes one `experience_audits` row.
+
+- If you have a **published config** with an explicit `'enabled' => env('AUDIT_POINTS', false)`, nothing changes until you update it — but periodic leaderboards will throw `MetricRequiresAuditingException` until you enable auditing.
+- If you relied on the old default to keep the audit table empty, set `AUDIT_POINTS=false` in your `.env`.
+- Audit rows only accrue from the moment auditing is on. A windowed board only sees activity recorded in the ledger, so "this week" boards are accurate one week after enabling.
+
 ### `setPoints()` now recalculates level and tier
 
 **Likelihood Of Impact: Medium** (silent behavior change for anyone using `setPoints`).

--- a/config/level-up.php
+++ b/config/level-up.php
@@ -109,6 +109,12 @@ return [
     | RankingMetric classes — register custom metrics by adding entries.
     | 'default_metric' is used when no metric is specified.
     |
+    | 'week_starts_on' sets the boundary of Period::Week as a Carbon
+    | day-of-week number: 0 (Sunday) through 6 (Saturday). Defaults to
+    | Monday. 'timezone' controls which timezone period boundaries
+    | (start of day/week/month) are computed in; null uses the
+    | application timezone.
+    |
     */
     'leaderboard' => [
         'default_metric' => 'xp',
@@ -117,6 +123,8 @@ return [
             'level' => LevelUp\Experience\Metrics\LevelMetric::class,
             'streak' => LevelUp\Experience\Metrics\StreakMetric::class,
         ],
+        'week_starts_on' => Carbon\CarbonInterface::MONDAY,
+        'timezone' => null,
     ],
 
     /*
@@ -165,11 +173,13 @@ return [
     | Audit
     | -------------------------------------------------------------------------
     |
-    | Set the audit configuration.
+    | Set the audit configuration. Auditing records every point transaction
+    | in the experience_audits ledger and is required for time-windowed
+    | (periodic) leaderboards. Enabled by default since v3.
     |
     */
     'audit' => [
-        'enabled' => env(key: 'AUDIT_POINTS', default: false),
+        'enabled' => env(key: 'AUDIT_POINTS', default: true),
     ],
 
     /*

--- a/resources/boost/skills/level-up-development/SKILL.md
+++ b/resources/boost/skills/level-up-development/SKILL.md
@@ -14,7 +14,7 @@ Use this skill when working with gamification features — adding experience poi
 - **Achievements** — Unlockable rewards, optionally with progress tracking, optionally gated by tier.
 - **Streaks** — Track consecutive daily activities with freeze support.
 - **Multipliers** — Database-backed point modifiers with scoping, scheduling, and configurable stacking strategies.
-- **Leaderboard** — Rank users by any metric (XP by default) with competition-style rank numbers, optionally scoped to a tier.
+- **Leaderboard** — Rank users by any metric (XP by default) with competition-style rank numbers, optionally scoped to a tier or a time period (day/week/month/custom).
 - **Auditing** — Automatic history of all XP changes, level-ups, and tier changes.
 
 ## Setup
@@ -550,6 +550,7 @@ Reference it in the condition: `['type' => 'custom', 'class' => HasVerifiedEmail
 ## Leaderboard
 
 ```php
+use LevelUp\Experience\Enums\Period;
 use LevelUp\Experience\Facades\Leaderboard;
 use LevelUp\Experience\Metrics\StreakMetric;
 
@@ -561,25 +562,35 @@ Leaderboard::by('level')->generate();           // Rank by current level
 Leaderboard::by(new StreakMetric(activity: $activity))->generate(); // Rank by current streak count for an Activity
 Leaderboard::by(MyMetric::class)->generate();   // Custom metric (class or instance)
 Leaderboard::forTier('Gold')->generate();       // Gold tier only
+Leaderboard::period(Period::Week)->generate();  // Points earned this week (also Period::Day / Period::Month)
+Leaderboard::since(start: now()->subDays(3))->generate(); // Custom range; optional until: bounds it
 Leaderboard::rankOf(user: $user);               // Exact rank (int), null if absent from the board
 Leaderboard::around(user: $user, range: 2);     // Up to 2 entries above + user + up to 2 below; empty if absent
 ```
 
-Returns `LeaderboardEntry` objects — `$entry->user` (with `experience` eager-loaded), `$entry->score`, and `$entry->rank` — ordered by score descending, then user key ascending. Ranks use competition semantics (tied scores share a rank; the next rank is skipped: 1, 1, 3) and are board-wide even when limiting or paginating. `rankOf()` and `around()` compose with `by()`. Ranks are computed with SQL window functions (requires SQLite 3.25+, MySQL 8+, or PostgreSQL). Metrics are registered in `level-up.leaderboard.metrics` (custom ones implement `LevelUp\Experience\Contracts\RankingMetric`); unknown keys throw `MetricNotFoundException`, disabled-feature metrics throw `MetricDisabledException`.
+Returns `LeaderboardEntry` objects — `$entry->user` (with `experience` eager-loaded), `$entry->score`, and `$entry->rank` — ordered by score descending, then user key ascending. Ranks use competition semantics (tied scores share a rank; the next rank is skipped: 1, 1, 3) and are board-wide even when limiting or paginating. `rankOf()` and `around()` compose with `by()`, `period()`, and `since()`. Ranks are computed with SQL window functions (requires SQLite 3.25+, MySQL 8+, or PostgreSQL). Metrics are registered in `level-up.leaderboard.metrics` (custom ones implement `LevelUp\Experience\Contracts\RankingMetric`); unknown keys throw `MetricNotFoundException`, disabled-feature metrics throw `MetricDisabledException`.
 
 Built-in metrics: `xp` (experience points, the default), `level` (current level), and `streak` (current streak count for an Activity). `level` and `streak` are state metrics — they rank by a current snapshot, and users without the relevant record are absent from the board. The streak metric requires an Activity: construct the instance (`new StreakMetric(activity: $activity)`); using the bare `streak` registry key without one throws `MetricRequiresActivityException`.
 
+### Time Periods
+
+`period(Period::Day|Week|Month)` and `since(start:, until:)` window a board to points earned inside the range, computed from the `experience_audits` ledger as `add` rows minus `remove` rows (state-change rows — `reset`, `level_up`, `tier_up`, `tier_down` — never count). Requires auditing (the v3 default); with auditing explicitly disabled, a periodic board throws `MetricRequiresAuditingException`. Only `Windowable` metrics support periods — `xp` does; `level` and `streak` throw `MetricNotWindowableException`. Custom metrics opt in by implementing `LevelUp\Experience\Contracts\Windowable` (`windowedScoreExpression($start, $end)`; `$end` is `null` for an open-ended `since()`).
+
+`setPoints()` writes no audit record, so it never moves a periodic board (administrative override, not earned activity) — the all-time board sees it immediately. Users with no qualifying audit rows in the window are absent from the board. All-time boards (no period) read `experiences.experience_points` directly and never scan the ledger.
+
+Period boundary config under `level-up.leaderboard`: `week_starts_on` (Carbon day-of-week, default `CarbonInterface::MONDAY`) and `timezone` (default `null` = app timezone) control where day/week/month boundaries fall.
+
 ## Auditing
 
-Enable in config:
+Enabled by default since v3 (periodic leaderboards source scores from the ledger):
 
 ```php
 'audit' => [
-    'enabled' => env('AUDIT_POINTS', false),
+    'enabled' => env('AUDIT_POINTS', true),
 ],
 ```
 
-When enabled, every `addPoints()`, `deductPoints()`, `levelUp()`, and tier change creates an `experience_audits` record.
+When enabled, every `addPoints()`, `deductPoints()`, `levelUp()`, and tier change creates an `experience_audits` record. `setPoints()` writes no audit record.
 
 ```php
 $user->experienceHistory;   // HasMany to ExperienceAudit

--- a/src/Contracts/Windowable.php
+++ b/src/Contracts/Windowable.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LevelUp\Experience\Contracts;
+
+use Carbon\CarbonInterface;
+use Illuminate\Contracts\Database\Query\Builder;
+
+interface Windowable
+{
+    public function windowedScoreExpression(CarbonInterface $start, ?CarbonInterface $end = null): Builder;
+}

--- a/src/Enums/Period.php
+++ b/src/Enums/Period.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LevelUp\Experience\Enums;
+
+use Carbon\CarbonImmutable;
+use Carbon\CarbonInterface;
+use LevelUp\Experience\Support\PeriodRange;
+
+enum Period: string
+{
+    case Day = 'day';
+    case Week = 'week';
+    case Month = 'month';
+
+    public function range(): PeriodRange
+    {
+        $now = CarbonImmutable::now(timezone: $this->timezone());
+
+        $start = match ($this) {
+            self::Day => $now->startOfDay(),
+            self::Week => $now->startOfWeek(weekStartsAt: config()->integer(key: 'level-up.leaderboard.week_starts_on', default: CarbonInterface::MONDAY)),
+            self::Month => $now->startOfMonth(),
+        };
+
+        $end = match ($this) {
+            self::Day => $start->addDay(),
+            self::Week => $start->addWeek(),
+            self::Month => $start->addMonth(),
+        };
+
+        $appTimezone = config()->string(key: 'app.timezone');
+
+        return new PeriodRange(
+            start: $start->setTimezone(timeZone: $appTimezone),
+            end: $end->setTimezone(timeZone: $appTimezone),
+        );
+    }
+
+    private function timezone(): string
+    {
+        $timezone = config(key: 'level-up.leaderboard.timezone');
+
+        return is_string($timezone) ? $timezone : config()->string(key: 'app.timezone');
+    }
+}

--- a/src/Exceptions/MetricNotWindowableException.php
+++ b/src/Exceptions/MetricNotWindowableException.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LevelUp\Experience\Exceptions;
+
+use Exception;
+use LevelUp\Experience\Contracts\RankingMetric;
+
+final class MetricNotWindowableException extends Exception
+{
+    public static function forMetric(RankingMetric $metric): self
+    {
+        return new self(message: "The [{$metric->key()}] leaderboard metric ranks by current state and does not support time Periods. Remove the period()/since() call, or rank by a Windowable metric such as [xp].");
+    }
+}

--- a/src/Exceptions/MetricRequiresAuditingException.php
+++ b/src/Exceptions/MetricRequiresAuditingException.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LevelUp\Experience\Exceptions;
+
+use Exception;
+use LevelUp\Experience\Contracts\RankingMetric;
+
+final class MetricRequiresAuditingException extends Exception
+{
+    public static function forMetric(RankingMetric $metric): self
+    {
+        return new self(message: "The [{$metric->key()}] leaderboard metric sources periodic Scores from the experience audit ledger, but auditing is disabled. Enable [level-up.audit.enabled] to use time Periods.");
+    }
+}

--- a/src/Metrics/ExperienceMetric.php
+++ b/src/Metrics/ExperienceMetric.php
@@ -4,11 +4,15 @@ declare(strict_types=1);
 
 namespace LevelUp\Experience\Metrics;
 
+use Carbon\CarbonInterface;
 use Illuminate\Contracts\Database\Query\Builder;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use LevelUp\Experience\Contracts\RankingMetric;
+use LevelUp\Experience\Contracts\Windowable;
+use LevelUp\Experience\Enums\AuditType;
+use LevelUp\Experience\Exceptions\MetricRequiresAuditingException;
 
-class ExperienceMetric implements RankingMetric
+class ExperienceMetric implements RankingMetric, Windowable
 {
     public function key(): string
     {
@@ -47,5 +51,36 @@ class ExperienceMetric implements RankingMetric
             ->latest()
             ->take(value: 1)
             ->toBase();
+    }
+
+    public function windowedScoreExpression(CarbonInterface $start, ?CarbonInterface $end = null): Builder
+    {
+        throw_unless(config()->boolean(key: 'level-up.audit.enabled'), exception: MetricRequiresAuditingException::forMetric($this));
+
+        $auditModel = config(key: 'level-up.models.experience_audit');
+
+        $query = $auditModel::query()->toBase();
+        $grammar = $query->getGrammar();
+
+        $query
+            ->selectRaw(expression: sprintf(
+                'SUM(CASE WHEN %s = ? THEN %s ELSE -%s END)',
+                $grammar->wrap(value: 'type'),
+                $grammar->wrap(value: 'points'),
+                $grammar->wrap(value: 'points'),
+            ), bindings: [AuditType::Add->value])
+            ->whereIn(column: 'type', values: [AuditType::Add->value, AuditType::Remove->value])
+            ->whereColumn(
+                first: config(key: 'level-up.user.foreign_key'),
+                operator: '=',
+                second: config(key: 'level-up.user.users_table').'.id',
+            )
+            ->where(column: 'created_at', operator: '>=', value: $start);
+
+        if ($end instanceof CarbonInterface) {
+            $query->where(column: 'created_at', operator: '<', value: $end);
+        }
+
+        return $query;
     }
 }

--- a/src/Services/LeaderboardService.php
+++ b/src/Services/LeaderboardService.php
@@ -4,16 +4,23 @@ declare(strict_types=1);
 
 namespace LevelUp\Experience\Services;
 
+use Carbon\CarbonImmutable;
+use Carbon\CarbonInterface;
+use Illuminate\Contracts\Database\Query\Builder as BaseBuilder;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use LevelUp\Experience\Contracts\RankingMetric;
+use LevelUp\Experience\Contracts\Windowable;
+use LevelUp\Experience\Enums\Period;
 use LevelUp\Experience\Exceptions\MetricDisabledException;
 use LevelUp\Experience\Exceptions\MetricNotFoundException;
+use LevelUp\Experience\Exceptions\MetricNotWindowableException;
 use LevelUp\Experience\Models\Tier;
 use LevelUp\Experience\Support\LeaderboardEntry;
+use LevelUp\Experience\Support\PeriodRange;
 
 class LeaderboardService
 {
@@ -22,6 +29,8 @@ class LeaderboardService
     private ?Tier $tier = null;
 
     private ?RankingMetric $metric = null;
+
+    private ?PeriodRange $range = null;
 
     public function __construct()
     {
@@ -33,6 +42,21 @@ class LeaderboardService
         $this->metric = $this->resolveMetric($metric);
 
         return $this;
+    }
+
+    public function period(Period $period): static
+    {
+        return $this->scopeToRange(range: $period->range());
+    }
+
+    public function since(CarbonInterface $start, ?CarbonInterface $until = null): static
+    {
+        $appTimezone = config()->string(key: 'app.timezone');
+
+        return $this->scopeToRange(range: new PeriodRange(
+            start: CarbonImmutable::instance(date: $start)->setTimezone(timeZone: $appTimezone),
+            end: $until instanceof CarbonInterface ? CarbonImmutable::instance(date: $until)->setTimezone(timeZone: $appTimezone) : null,
+        ));
     }
 
     public function forTier(string|Tier $tier): static
@@ -49,9 +73,9 @@ class LeaderboardService
 
     public function generate(bool $paginate = false, ?int $limit = null): Collection|LengthAwarePaginator
     {
-        [$metric, $tier] = $this->consumeContext();
+        [$metric, $tier, $range] = $this->consumeContext();
 
-        $query = $this->rankedQuery(metric: $metric, tier: $tier)->take(value: $limit);
+        $query = $this->rankedQuery(metric: $metric, tier: $tier, range: $range)->take(value: $limit);
 
         return $paginate
             ? $query->paginate()->through(callback: fn (Model $user): LeaderboardEntry => $this->toEntry($user))
@@ -60,10 +84,10 @@ class LeaderboardService
 
     public function rankOf(Model $user): ?int
     {
-        [$metric, $tier] = $this->consumeContext();
+        [$metric, $tier, $range] = $this->consumeContext();
 
         $rank = DB::query()
-            ->fromSub(query: $this->rankedQuery(metric: $metric, tier: $tier), as: 'ranked')
+            ->fromSub(query: $this->rankedQuery(metric: $metric, tier: $tier, range: $range), as: 'ranked')
             ->where(column: $user->getKeyName(), operator: '=', value: $user->getKey())
             ->value(column: 'rank');
 
@@ -72,9 +96,9 @@ class LeaderboardService
 
     public function around(Model $user, int $range): Collection
     {
-        [$metric, $tier] = $this->consumeContext();
+        [$metric, $tier, $periodRange] = $this->consumeContext();
 
-        $ranked = $this->rankedQuery(metric: $metric, tier: $tier);
+        $ranked = $this->rankedQuery(metric: $metric, tier: $tier, range: $periodRange);
         $grammar = $ranked->getQuery()->getGrammar();
 
         $positioned = (clone $ranked)->selectRaw(expression: sprintf(
@@ -104,23 +128,59 @@ class LeaderboardService
     }
 
     /**
-     * @return array{0: RankingMetric, 1: ?Tier}
+     * @return array{0: RankingMetric, 1: ?Tier, 2: ?PeriodRange}
      */
     private function consumeContext(): array
     {
         [$tier, $this->tier] = [$this->tier, null];
+        [$range, $this->range] = [$this->range, null];
         [$metric, $this->metric] = [$this->metric ?? $this->defaultMetric(), null];
 
         throw_unless($metric->enabled(), exception: MetricDisabledException::forMetric($metric));
 
-        return [$metric, $tier];
+        if ($range instanceof PeriodRange) {
+            $this->guardWindowable(metric: $metric);
+        }
+
+        return [$metric, $tier, $range];
     }
 
-    private function rankedQuery(RankingMetric $metric, ?Tier $tier): Builder
+    private function scopeToRange(PeriodRange $range): static
+    {
+        $metric = $this->metric;
+
+        if ($metric instanceof RankingMetric) {
+            $this->guardWindowable(metric: $metric);
+        }
+
+        $this->range = $range;
+
+        return $this;
+    }
+
+    private function guardWindowable(RankingMetric $metric): void
+    {
+        if ($metric instanceof Windowable) {
+            return;
+        }
+
+        [$this->metric, $this->tier, $this->range] = [null, null, null];
+
+        throw MetricNotWindowableException::forMetric($metric);
+    }
+
+    private function scoreExpressionFor(RankingMetric $metric, ?PeriodRange $range): BaseBuilder
+    {
+        return $range instanceof PeriodRange && $metric instanceof Windowable
+            ? $metric->windowedScoreExpression(start: $range->start, end: $range->end)
+            : $metric->scoreExpression();
+    }
+
+    private function rankedQuery(RankingMetric $metric, ?Tier $tier, ?PeriodRange $range): Builder
     {
         $scored = $this->userModel::query()
             ->select(columns: config(key: 'level-up.user.users_table').'.*')
-            ->selectSub(query: $metric->scoreExpression(), as: 'score')
+            ->selectSub(query: $this->scoreExpressionFor(metric: $metric, range: $range), as: 'score')
             ->tap(callback: fn (Builder $query): Builder => $metric->constrain($query))
             ->when($tier instanceof Tier, fn (Builder $query): Builder => $query->whereHas(
                 'experience',
@@ -130,7 +190,7 @@ class LeaderboardService
         $grammar = $scored->getQuery()->getGrammar();
         $keyName = $scored->getModel()->getKeyName();
 
-        return $this->userModel::query()
+        $ranked = $this->userModel::query()
             ->fromSub(query: $scored, as: 'board')
             ->select(columns: 'board.*')
             ->selectRaw(expression: sprintf(
@@ -141,6 +201,12 @@ class LeaderboardService
             ->with(relations: ['experience'])
             ->orderByDesc(column: 'score')
             ->orderBy(column: $keyName);
+
+        if ($range instanceof PeriodRange) {
+            $ranked->whereNotNull(columns: 'score');
+        }
+
+        return $ranked;
     }
 
     private function toEntry(Model $user): LeaderboardEntry

--- a/src/Support/PeriodRange.php
+++ b/src/Support/PeriodRange.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LevelUp\Experience\Support;
+
+use Carbon\CarbonImmutable;
+
+final readonly class PeriodRange
+{
+    public function __construct(
+        public CarbonImmutable $start,
+        public ?CarbonImmutable $end = null,
+    ) {}
+}

--- a/tests/Services/LeaderboardPeriodsTest.php
+++ b/tests/Services/LeaderboardPeriodsTest.php
@@ -1,0 +1,242 @@
+<?php
+
+declare(strict_types=1);
+
+uses()->group('leaderboard');
+
+use Illuminate\Support\Carbon;
+use LevelUp\Experience\Enums\AuditType;
+use LevelUp\Experience\Enums\Period;
+use LevelUp\Experience\Exceptions\MetricNotWindowableException;
+use LevelUp\Experience\Exceptions\MetricRequiresAuditingException;
+use LevelUp\Experience\Facades\Leaderboard;
+use LevelUp\Experience\Support\LeaderboardEntry;
+use LevelUp\Experience\Tests\Fixtures\User;
+
+beforeEach(function (): void {
+    config(['level-up.user.model' => User::class]);
+    config(['level-up.multiplier.enabled' => false]);
+});
+
+it(description: 'windows the xp board to points earned within the current day', closure: function (): void {
+    $this->travelTo(Illuminate\Support\Facades\Date::parse(time: '2026-06-03 12:00:00'));
+    tap(User::newFactory()->create())->addPoints(50);
+
+    $this->travelTo(Illuminate\Support\Facades\Date::parse(time: '2026-06-05 12:00:00'));
+    $todayEarner = tap(User::newFactory()->create())->addPoints(44);
+
+    $entries = Leaderboard::period(period: Period::Day)->generate();
+
+    expect($entries)->toHaveCount(count: 1)
+        ->and($entries->first())->toBeInstanceOf(class: LeaderboardEntry::class)
+        ->and($entries->first()->user->id)->toEqual($todayEarner->id)
+        ->and($entries->first()->score)->toBe(expected: 44);
+});
+
+it(description: 'computes the windowed score as points added minus points removed', closure: function (): void {
+    $user = tap(User::newFactory()->create())->addPoints(80);
+    $user->deductPoints(30);
+
+    $entries = Leaderboard::period(period: Period::Day)->generate();
+
+    expect($entries)->toHaveCount(count: 1)
+        ->and($entries->first()->score)->toBe(expected: 50);
+});
+
+it(description: 'excludes state-change audit rows from the windowed score', closure: function (): void {
+    $user = tap(User::newFactory()->create())->addPoints(150);
+
+    expect($user->experienceHistory()->where(column: 'type', operator: '=', value: AuditType::LevelUp->value)->exists())->toBeTrue();
+
+    $user->experienceHistory()->create(attributes: ['points' => 150, 'type' => AuditType::Reset->value]);
+    $user->experienceHistory()->create(attributes: ['points' => 150, 'type' => AuditType::TierUp->value]);
+    $user->experienceHistory()->create(attributes: ['points' => 150, 'type' => AuditType::TierDown->value]);
+
+    $entries = Leaderboard::period(period: Period::Day)->generate();
+
+    expect($entries->first()->score)->toBe(expected: 150);
+});
+
+it(description: 'keeps the all-time board reading experience points without the audit ledger', closure: function (): void {
+    config(['level-up.audit.enabled' => false]);
+
+    $user = tap(User::newFactory()->create())->addPoints(120);
+
+    expect($user->experienceHistory()->count())->toBe(expected: 0);
+
+    $entries = Leaderboard::generate();
+
+    expect($entries)->toHaveCount(count: 1)
+        ->and($entries->first()->score)->toBe(expected: 120);
+});
+
+it(description: 'ignores setPoints overrides on periodic boards while the all-time board sees them', closure: function (): void {
+    $earner = tap(User::newFactory()->create())->addPoints(10);
+    $overridden = tap(User::newFactory()->create())->addPoints(5);
+    $overridden->setPoints(1000);
+
+    $periodic = Leaderboard::period(period: Period::Day)->generate();
+    $allTime = Leaderboard::generate();
+
+    expect($periodic->map(fn (LeaderboardEntry $entry): int|float => $entry->score)->toArray())->toBe([10, 5])
+        ->and($periodic->first()->user->id)->toEqual($earner->id)
+        ->and($allTime->first()->user->id)->toEqual($overridden->id)
+        ->and($allTime->first()->score)->toBe(expected: 1000);
+});
+
+it(description: 'throws immediately when selecting a period for a non-Windowable metric', closure: function (): void {
+    Leaderboard::by(metric: 'level')->period(period: Period::Day);
+})->throws(exception: MetricNotWindowableException::class, exceptionMessage: 'level');
+
+it(description: 'throws when generating a periodic board after switching to a non-Windowable metric', closure: function (): void {
+    Leaderboard::period(period: Period::Day)->by(metric: 'level')->generate();
+})->throws(exception: MetricNotWindowableException::class, exceptionMessage: 'level');
+
+it(description: 'throws a descriptive exception when a periodic board is requested with auditing disabled', closure: function (): void {
+    config(['level-up.audit.enabled' => false]);
+
+    tap(User::newFactory()->create())->addPoints(50);
+
+    Leaderboard::period(period: Period::Day)->generate();
+})->throws(exception: MetricRequiresAuditingException::class, exceptionMessage: 'level-up.audit.enabled');
+
+it(description: 'windows the board to a custom open-ended range with since', closure: function (): void {
+    $this->travelTo(Illuminate\Support\Facades\Date::parse(time: '2026-06-01 12:00:00'));
+    $earlyEarner = tap(User::newFactory()->create())->addPoints(100);
+
+    $this->travelTo(Illuminate\Support\Facades\Date::parse(time: '2026-06-04 12:00:00'));
+    $recentEarner = tap(User::newFactory()->create())->addPoints(30);
+
+    $this->travelTo(Illuminate\Support\Facades\Date::parse(time: '2026-06-05 12:00:00'));
+    $earlyEarner->addPoints(20);
+
+    $entries = Leaderboard::since(start: Illuminate\Support\Facades\Date::parse(time: '2026-06-03 00:00:00'))->generate();
+
+    expect($entries->map(fn (LeaderboardEntry $entry): int|float => $entry->score)->toArray())->toBe([30, 20])
+        ->and($entries->first()->user->id)->toEqual($recentEarner->id)
+        ->and($entries->last()->user->id)->toEqual($earlyEarner->id);
+});
+
+it(description: 'bounds a custom range with an until timestamp, excluding rows at or after it', closure: function (): void {
+    $this->travelTo(Illuminate\Support\Facades\Date::parse(time: '2026-06-04 12:00:00'));
+    $insideEarner = tap(User::newFactory()->create())->addPoints(30);
+
+    $this->travelTo(Illuminate\Support\Facades\Date::parse(time: '2026-06-05 00:00:00'));
+    $boundaryEarner = tap(User::newFactory()->create())->addPoints(99);
+
+    $entries = Leaderboard::since(
+        start: Illuminate\Support\Facades\Date::parse(time: '2026-06-03 00:00:00'),
+        until: Illuminate\Support\Facades\Date::parse(time: '2026-06-05 00:00:00'),
+    )->generate();
+
+    expect($entries)->toHaveCount(count: 1)
+        ->and($entries->first()->user->id)->toEqual($insideEarner->id)
+        ->and(Leaderboard::since(start: Illuminate\Support\Facades\Date::parse(time: '2026-06-05 00:00:00'))->rankOf(user: $boundaryEarner))->toBe(expected: 1);
+});
+
+it(description: 'starts the week on Monday by default, including rows from the boundary onwards', closure: function (): void {
+    $this->travelTo(Illuminate\Support\Facades\Date::parse(time: '2026-05-31 23:59:00'));
+    tap(User::newFactory()->create())->addPoints(70);
+
+    $this->travelTo(Illuminate\Support\Facades\Date::parse(time: '2026-06-01 00:00:00'));
+    $mondayEarner = tap(User::newFactory()->create())->addPoints(80);
+
+    $this->travelTo(Illuminate\Support\Facades\Date::parse(time: '2026-06-03 12:00:00'));
+
+    $entries = Leaderboard::period(period: Period::Week)->generate();
+
+    expect($entries)->toHaveCount(count: 1)
+        ->and($entries->first()->user->id)->toEqual($mondayEarner->id)
+        ->and($entries->first()->score)->toBe(expected: 80);
+});
+
+it(description: 'respects a configured week start day', closure: function (): void {
+    config(['level-up.leaderboard.week_starts_on' => Carbon::SUNDAY]);
+
+    $this->travelTo(Illuminate\Support\Facades\Date::parse(time: '2026-05-30 23:59:00'));
+    tap(User::newFactory()->create())->addPoints(70);
+
+    $this->travelTo(Illuminate\Support\Facades\Date::parse(time: '2026-05-31 08:00:00'));
+    $sundayEarner = tap(User::newFactory()->create())->addPoints(80);
+
+    $this->travelTo(Illuminate\Support\Facades\Date::parse(time: '2026-06-03 12:00:00'));
+
+    $entries = Leaderboard::period(period: Period::Week)->generate();
+
+    expect($entries)->toHaveCount(count: 1)
+        ->and($entries->first()->user->id)->toEqual($sundayEarner->id);
+});
+
+it(description: 'computes period boundaries in the configured timezone', closure: function (): void {
+    $this->travelTo(Illuminate\Support\Facades\Date::parse(time: '2026-06-05 03:00:00', timezone: 'UTC'));
+    $lateNightEarner = tap(User::newFactory()->create())->addPoints(60);
+
+    $this->travelTo(Illuminate\Support\Facades\Date::parse(time: '2026-06-05 05:00:00', timezone: 'UTC'));
+    $morningEarner = tap(User::newFactory()->create())->addPoints(40);
+
+    $this->travelTo(Illuminate\Support\Facades\Date::parse(time: '2026-06-05 12:00:00', timezone: 'UTC'));
+
+    $utcBoard = Leaderboard::period(period: Period::Day)->generate();
+
+    expect($utcBoard)->toHaveCount(count: 2);
+
+    config(['level-up.leaderboard.timezone' => 'America/New_York']);
+
+    $newYorkBoard = Leaderboard::period(period: Period::Day)->generate();
+
+    expect($newYorkBoard)->toHaveCount(count: 1)
+        ->and($newYorkBoard->first()->user->id)->toEqual($morningEarner->id)
+        ->and(Leaderboard::period(period: Period::Day)->rankOf(user: $lateNightEarner))->toBeNull();
+});
+
+it(description: 'windows the board to the current month', closure: function (): void {
+    $this->travelTo(Illuminate\Support\Facades\Date::parse(time: '2026-05-31 23:00:00'));
+    tap(User::newFactory()->create())->addPoints(70);
+
+    $this->travelTo(Illuminate\Support\Facades\Date::parse(time: '2026-06-01 10:00:00'));
+    $juneEarner = tap(User::newFactory()->create())->addPoints(80);
+
+    $this->travelTo(Illuminate\Support\Facades\Date::parse(time: '2026-06-15 12:00:00'));
+
+    $entries = Leaderboard::period(period: Period::Month)->generate();
+
+    expect($entries)->toHaveCount(count: 1)
+        ->and($entries->first()->user->id)->toEqual($juneEarner->id);
+});
+
+it(description: 'treats users without qualifying audit rows in the window as absent from the board', closure: function (): void {
+    $this->travelTo(Illuminate\Support\Facades\Date::parse(time: '2026-06-03 12:00:00'));
+    $pastEarner = tap(User::newFactory()->create())->addPoints(500);
+
+    $this->travelTo(Illuminate\Support\Facades\Date::parse(time: '2026-06-05 12:00:00'));
+    tap(User::newFactory()->create())->addPoints(44);
+
+    expect(Leaderboard::period(period: Period::Day)->rankOf(user: $pastEarner))->toBeNull()
+        ->and(Leaderboard::period(period: Period::Day)->around(user: $pastEarner, range: 2))->toBeEmpty()
+        ->and(Leaderboard::period(period: Period::Day)->rankOf(user: $this->user))->toBeNull();
+});
+
+it(description: 'composes periodic boards with ranks, ties, rankOf and around', closure: function (): void {
+    $this->travelTo(Illuminate\Support\Facades\Date::parse(time: '2026-06-03 12:00:00'));
+    $allTimeLeader = tap(User::newFactory()->create())->addPoints(900);
+
+    $this->travelTo(Illuminate\Support\Facades\Date::parse(time: '2026-06-05 12:00:00'));
+    $tiedOne = tap(User::newFactory()->create())->addPoints(200);
+    $tiedTwo = tap(User::newFactory()->create())->addPoints(200);
+    $third = tap(User::newFactory()->create())->addPoints(100);
+    $allTimeLeader->addPoints(50);
+
+    $entries = Leaderboard::period(period: Period::Day)->generate();
+
+    expect($entries->map(fn (LeaderboardEntry $entry): int|float => $entry->score)->toArray())->toBe([200, 200, 100, 50])
+        ->and($entries->map(fn (LeaderboardEntry $entry): int => $entry->rank)->toArray())->toBe([1, 1, 3, 4])
+        ->and(Leaderboard::period(period: Period::Day)->rankOf(user: $tiedTwo))->toBe(expected: 1)
+        ->and(Leaderboard::period(period: Period::Day)->rankOf(user: $allTimeLeader))->toBe(expected: 4)
+        ->and(Leaderboard::rankOf(user: $allTimeLeader))->toBe(expected: 1);
+
+    $around = Leaderboard::period(period: Period::Day)->around(user: $third, range: 1);
+
+    expect($around)->toHaveCount(count: 3)
+        ->and($around->map(fn (LeaderboardEntry $entry): int => $entry->rank)->toArray())->toBe([1, 3, 4])
+        ->and($around[1]->user->id)->toEqual($third->id);
+});


### PR DESCRIPTION
Leaderboards can now answer "who earned the most XP this week?" — not just "who has the most XP ever?". Scope any XP board to a bounded time **Period**, with ranks, ties, `rankOf()` and `around()` all working inside the window.

## Time-windowed boards

```php
use LevelUp\Experience\Enums\Period;
use LevelUp\Experience\Facades\Leaderboard;

Leaderboard::period(Period::Day)->generate();   // points earned today
Leaderboard::period(Period::Week)->generate();  // points earned this week
Leaderboard::period(Period::Month)->generate(); // points earned this month

Leaderboard::period(Period::Week)->rankOf(user: $user);
Leaderboard::period(Period::Week)->around(user: $user, range: 2);
```

Or pick your own range with `since()` — open-ended, or bounded with `until:`:

```php
Leaderboard::since(start: now()->subDays(3))->generate();
Leaderboard::since(start: $seasonStart, until: $seasonEnd)->generate();
```

Windowed scores are computed from the `experience_audits` ledger: points **added minus points removed** inside the window, nothing else — state-change rows (`reset`, `level_up`, `tier_up`, `tier_down`) never count. Users with no qualifying activity in the window are absent from the board. Boards without a period are untouched: the all-time board still reads `experiences.experience_points` directly and never scans the ledger.

## Configurable boundaries

New keys under `level-up.leaderboard`:

```php
'week_starts_on' => Carbon\CarbonInterface::MONDAY, // 0 (Sunday) – 6 (Saturday)
'timezone' => null,                                 // null = app timezone
```

`week_starts_on` sets where `Period::Week` begins; `timezone` controls which timezone day/week/month boundaries are computed in, so "today" can mean your users' midnight rather than UTC's.

## Which metrics support periods

Only metrics implementing the new `Windowable` contract: built-in `xp` does. `level` and `streak` are state metrics — a current level isn't "earned this week" — so selecting a period for them throws `MetricNotWindowableException` with a clear message. Custom metrics opt in by implementing `LevelUp\Experience\Contracts\Windowable` (`windowedScoreExpression($start, $end)`).

## ⚠️ Breaking change: auditing now defaults to ON

`level-up.audit.enabled` flips from `false` to `true`, so periodic boards work out of the box. Every `addPoints()` / `deductPoints()` now writes one `experience_audits` row per transaction.

- Opt out with `AUDIT_POINTS=false` (or your published config) if you don't need point history or periodic boards.
- If auditing is explicitly disabled and a periodic board is requested, you get a descriptive `MetricRequiresAuditingException` — never a silently empty board.
- The ledger only accrues from the moment auditing is on, so windowed boards reflect activity recorded after enabling.

See the new UPGRADE.md section for details.

## Worth knowing

- `setPoints()` writes no audit record, so it deliberately never moves a periodic board — it's an administrative override, not earned activity. The all-time board sees the new total immediately.
- Window edges are half-open `[start, end)`: a row at exactly the week start counts; a row at exactly `until:` doesn't.

Stacked on #162 (`feat/v3-leaderboard-state-metrics`) — merge that first.

Closes #150