### PR TITLE
feat(v3): Board snapshots and rank-change events

### DIFF
--- a/README.md
+++ b/README.md
@@ -754,6 +754,56 @@ Declarations are validated loudly at resolution rather than producing a silently
 
 Why declare a board instead of just querying? Boards are the leaderboards the package will **track over time** — snapshots, rank-change events, and leagues (arriving in later releases) apply only to declared Boards. Ad-hoc queries stay exactly what they are: composed, executed, forgotten. Declare no boards and none of that machinery activates.
 
+### Snapshots and rank events
+
+A **Snapshot** is the leaderboard's memory: a persisted record of a Board's top entries at a point in time. Diffing consecutive snapshots produces rank *deltas* — "you climbed from #5 to #2" — which a stateless query can never compute. The `level-up:snapshot-boards` command writes one snapshot run per declared Board, diffs it against the previous run, dispatches rank events, and prunes old runs.
+
+Schedule the command from your application — the package never auto-registers scheduler entries:
+
+```php
+// routes/console.php
+use Illuminate\Support\Facades\Schedule;
+
+Schedule::command('level-up:snapshot-boards')->hourly();
+```
+
+Each run stores the top **tracked depth** entries per Board — `track_top` in the board declaration, default 100:
+
+```php
+'boards' => [
+    'weekly-xp' => ['metric' => 'xp', 'period' => 'week', 'track_top' => 50],
+],
+```
+
+Diffing two runs dispatches three events, each carrying the board name:
+
+| Event | Properties | When |
+|-------|-----------|------|
+| `LeaderboardRankChanged` | `Model $user`, `string $board`, `int $from`, `int $to` | A user moved rank within the tracked depth |
+| `UserEnteredTrackedDepth` | `Model $user`, `string $board`, `int $rank` | A user broke into the tracked depth |
+| `UserLeftTrackedDepth` | `Model $user`, `string $board`, `int $previousRank` | A user dropped out of the tracked depth |
+
+Below the tracked depth a Board is **silent by design**: no snapshot rows, no events. "You dropped from #6,389 to #6,412" is not a thing the package emits — raise `track_top` if you want deeper tracking and are happy to own the cost. Ties use the same competition semantics as live queries, so a tie breaking only events the users whose rank number actually changed.
+
+Two semantics worth knowing:
+
+- **The first run of a Board is silent.** Events are deltas between runs; with no previous run there is no delta — the first run just writes the baseline snapshot.
+- **Re-running within the same instant replaces that run.** A run is identified by its timestamp (to the second), so an immediate re-run overwrites the same run's rows instead of duplicating them, and recomputes the same diff against the run before it.
+
+Old runs are pruned by the same command per `level-up.leaderboard.snapshots.retention_days` (default 30):
+
+```php
+'leaderboard' => [
+    // ...
+    'snapshots' => [
+        'retention_days' => 30,
+    ],
+],
+```
+
+> [!NOTE]
+> Snapshots are **not a cache** for live queries — `rankOf()` and `around()` always compute fresh, for any user at any depth. Snapshots exist solely to remember past runs so rank deltas can be evented.
+
 ### Custom metrics
 
 Rank by anything you can express as a SQL score: implement `LevelUp\Experience\Contracts\RankingMetric` — a stable `key()`, a `label()`, an `enabled()` check, a `constrain()` that scopes the user query to eligible users, and a `scoreExpression()` subquery yielding one numeric score per user — then register the class in `level-up.leaderboard.metrics`.

--- a/config/level-up.php
+++ b/config/level-up.php
@@ -19,6 +19,7 @@ return [
         'multiplier_tier' => LevelUp\Experience\Models\Pivots\MultiplierTier::class,
         'challenge' => LevelUp\Experience\Models\Challenge::class,
         'challenge_user' => LevelUp\Experience\Models\Pivots\ChallengeUser::class,
+        'leaderboard_snapshot' => LevelUp\Experience\Models\LeaderboardSnapshot::class,
     ],
 
     /*
@@ -98,6 +99,7 @@ return [
         'multiplier_tier' => 'multiplier_tier',
         'challenges' => 'challenges',
         'challenge_user' => 'challenge_user',
+        'leaderboard_snapshots' => 'leaderboard_snapshots',
     ],
 
     /*
@@ -118,8 +120,13 @@ return [
     | 'boards' declares named Boards — leaderboards the package can
     | track over time. Each entry maps a board name to a 'metric'
     | (required registry key), an optional 'period' ('day', 'week',
-    | or 'month'), and an optional 'tier' (a tier name). For example:
+    | or 'month'), an optional 'tier' (a tier name), and an optional
+    | 'track_top' (the tracked depth — how many top entries the
+    | snapshot run stores and events, default 100). For example:
     | 'weekly-xp' => ['metric' => 'xp', 'period' => 'week'].
+    |
+    | 'snapshots.retention_days' controls how long snapshot runs are
+    | kept; the level-up:snapshot-boards command prunes older runs.
     |
     */
     'leaderboard' => [
@@ -132,6 +139,9 @@ return [
             'challenges' => LevelUp\Experience\Metrics\ChallengeMetric::class,
         ],
         'boards' => [],
+        'snapshots' => [
+            'retention_days' => 30,
+        ],
         'week_starts_on' => Carbon\CarbonInterface::MONDAY,
         'timezone' => null,
     ],

--- a/database/migrations/create_leaderboard_snapshots_table.php.stub
+++ b/database/migrations/create_leaderboard_snapshots_table.php.stub
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create(config('level-up.tables.leaderboard_snapshots'), function (Blueprint $table) {
+            $table->entityId();
+            $table->string(column: 'board');
+            $table->userForeignId()->constrained(config('level-up.user.users_table'));
+            $table->unsignedInteger(column: 'rank');
+            $table->double(column: 'score');
+            $table->timestamp(column: 'run_at');
+            $table->timestamps();
+
+            $table->index(['board', 'run_at']);
+            $table->index('run_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists(config('level-up.tables.leaderboard_snapshots'));
+    }
+};

--- a/rector.php
+++ b/rector.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 use Rector\Config\RectorConfig;
 use Rector\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector;
 use RectorLaravel\Rector\Class_\AddHasFactoryToModelsRector;
+use RectorLaravel\Rector\Class_\DescriptionPropertyToDescriptionAttributeRector;
+use RectorLaravel\Rector\Class_\SignaturePropertyToSignatureAttributeRector;
 use RectorLaravel\Rector\Class_\TablePropertyToTableAttributeRector;
 use RectorLaravel\Rector\ClassMethod\MakeModelAttributesAndScopesProtectedRector;
 use RectorLaravel\Rector\FuncCall\RemoveDumpDataDeadCodeRector;
@@ -23,6 +25,8 @@ return RectorConfig::configure()
         AddHasFactoryToModelsRector::class,
         MakeModelAttributesAndScopesProtectedRector::class,
         TablePropertyToTableAttributeRector::class,
+        DescriptionPropertyToDescriptionAttributeRector::class,
+        SignaturePropertyToSignatureAttributeRector::class,
     ])
     ->withPreparedSets(
         deadCode: true,

--- a/resources/boost/skills/level-up-development/SKILL.md
+++ b/resources/boost/skills/level-up-development/SKILL.md
@@ -588,18 +588,24 @@ Period boundary config under `level-up.leaderboard`: `week_starts_on` (Carbon da
 
 ### Named Boards
 
-A **Board** is a *declared* leaderboard — a named metric/period(/tier) combination registered in config — as opposed to an ad-hoc fluent query (composed, executed, forgotten). Only declared Boards will be tracked over time (snapshots, rank events, leagues — later releases); declaring none means none of that machinery activates.
+A **Board** is a *declared* leaderboard — a named metric/period(/tier) combination registered in config — as opposed to an ad-hoc fluent query (composed, executed, forgotten). Only declared Boards are tracked over time (snapshots, rank events; leagues — later releases); declaring none means none of that machinery activates.
 
 ```php
 'leaderboard' => [
     'boards' => [
         'weekly-xp' => ['metric' => 'xp', 'period' => 'week'],
-        'gold-race' => ['metric' => 'xp', 'period' => 'week', 'tier' => 'Gold'],
+        'gold-race' => ['metric' => 'xp', 'period' => 'week', 'tier' => 'Gold', 'track_top' => 50],
     ],
 ],
 ```
 
-`metric` is required (a `level-up.leaderboard.metrics` registry key), `period` is optional (`'day'`/`'week'`/`'month'` — the `Period` enum string values), `tier` is optional (a tier name). `Leaderboard::board('weekly-xp')` resolves the declaration into the same fluent query, so all refinements (`restrictTo()`, `rankOf()`, `around()`, `limit:`, `paginate:`) compose on top. Resolution validates loudly: unknown board name → `BoardNotFoundException`; missing or unknown `metric` → `MetricNotFoundException`; `period` on a non-Windowable metric → `MetricNotWindowableException`; invalid `period` string → `ValueError`; nonexistent `tier` name → `ModelNotFoundException`.
+`metric` is required (a `level-up.leaderboard.metrics` registry key), `period` is optional (`'day'`/`'week'`/`'month'` — the `Period` enum string values), `tier` is optional (a tier name), `track_top` is optional (the tracked depth — how many top entries are snapshotted and evented, default 100). `Leaderboard::board('weekly-xp')` resolves the declaration into the same fluent query, so all refinements (`restrictTo()`, `rankOf()`, `around()`, `limit:`, `paginate:`) compose on top. Resolution validates loudly: unknown board name → `BoardNotFoundException`; missing or unknown `metric` → `MetricNotFoundException`; `period` on a non-Windowable metric → `MetricNotWindowableException`; invalid `period` string → `ValueError`; nonexistent `tier` name → `ModelNotFoundException`.
+
+### Snapshots and rank events
+
+A **Snapshot** persists a Board's top `track_top` entries at a point in time (the `leaderboard_snapshots` table, `LeaderboardSnapshot` model: `board`, `user_id`, `rank`, `score`, `run_at`). The `level-up:snapshot-boards` command snapshots every declared Board, diffs against that Board's previous run, dispatches rank events, and prunes runs older than `level-up.leaderboard.snapshots.retention_days` (default 30). The host schedules it (e.g. `Schedule::command('level-up:snapshot-boards')->hourly()` in `routes/console.php`) — the package never auto-registers scheduler entries.
+
+Diff semantics: rank movement within the tracked depth → `LeaderboardRankChanged`; crossing the boundary → `UserEnteredTrackedDepth` / `UserLeftTrackedDepth`; below the tracked depth a Board is **silent by design** (no rows, no events — don't "fix" this). The first run of a Board is silent (no previous run, no delta). A re-run within the same instant replaces that run's rows (a run is identified by `run_at` to the second) and recomputes the same diff. Snapshots are *not* a cache — `rankOf()`/`around()` always compute fresh at any depth.
 
 ## Auditing
 
@@ -650,6 +656,9 @@ AuditType::TierDown; // 'tier_down'
 | `ChallengeCompleted` | `Challenge $challenge`, `Model $user` | Challenge conditions met, rewards dispatched |
 | `ChallengeEnrolled` | `Challenge $challenge`, `Model $user` | User enrolled in challenge |
 | `ChallengeUnenrolled` | `Challenge $challenge`, `Model $user` | User unenrolled from challenge |
+| `LeaderboardRankChanged` | `Model $user`, `string $board`, `int $from`, `int $to` | Snapshot run found rank movement within a Board's tracked depth |
+| `UserEnteredTrackedDepth` | `Model $user`, `string $board`, `int $rank` | Snapshot run found a user broke into a Board's tracked depth |
+| `UserLeftTrackedDepth` | `Model $user`, `string $board`, `int $previousRank` | Snapshot run found a user dropped out of a Board's tracked depth |
 
 ## Common Patterns
 

--- a/src/Commands/SnapshotBoardsCommand.php
+++ b/src/Commands/SnapshotBoardsCommand.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LevelUp\Experience\Commands;
+
+use Carbon\CarbonInterface;
+use Illuminate\Console\Command;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
+use LevelUp\Experience\Events\LeaderboardRankChanged;
+use LevelUp\Experience\Events\UserEnteredTrackedDepth;
+use LevelUp\Experience\Events\UserLeftTrackedDepth;
+use LevelUp\Experience\Models\LeaderboardSnapshot;
+use LevelUp\Experience\Services\LeaderboardService;
+use LevelUp\Experience\Support\LeaderboardEntry;
+
+#[\Illuminate\Console\Attributes\Description('Snapshot the top entries of every declared leaderboard Board, dispatch rank events, and prune old runs.')]
+#[\Illuminate\Console\Attributes\Signature('level-up:snapshot-boards')]
+class SnapshotBoardsCommand extends Command
+{
+    public function handle(LeaderboardService $leaderboard): int
+    {
+        $boards = config()->array(key: 'level-up.leaderboard.boards');
+        $runAt = now();
+
+        foreach (array_keys($boards) as $name) {
+            $this->snapshotBoard(leaderboard: $leaderboard, name: (string) $name, declaration: $boards[$name], runAt: $runAt);
+        }
+
+        $this->pruneStaleRuns(runAt: $runAt);
+
+        return self::SUCCESS;
+    }
+
+    private function pruneStaleRuns(CarbonInterface $runAt): void
+    {
+        $retentionDays = config()->integer(key: 'level-up.leaderboard.snapshots.retention_days', default: 30);
+
+        $snapshotModel = config(key: 'level-up.models.leaderboard_snapshot');
+
+        $snapshotModel::query()
+            ->where(column: 'run_at', operator: '<', value: $runAt->copy()->subDays($retentionDays))
+            ->delete();
+    }
+
+    private function snapshotBoard(LeaderboardService $leaderboard, string $name, mixed $declaration, CarbonInterface $runAt): void
+    {
+        $trackTop = is_array($declaration) && is_int($declaration['track_top'] ?? null) ? $declaration['track_top'] : 100;
+
+        /** @var Collection<int, LeaderboardEntry> $entries */
+        $entries = $leaderboard->board(name: $name)->generate(limit: $trackTop);
+
+        $snapshotModel = config(key: 'level-up.models.leaderboard_snapshot');
+        $userForeignKey = config()->string(key: 'level-up.user.foreign_key');
+
+        $previousRunAt = $snapshotModel::query()
+            ->where(column: 'board', operator: '=', value: $name)
+            ->where(column: 'run_at', operator: '<', value: $runAt)
+            ->max(column: 'run_at');
+
+        $snapshotModel::query()
+            ->where(column: 'board', operator: '=', value: $name)
+            ->where(column: 'run_at', operator: '=', value: $runAt)
+            ->delete();
+
+        foreach ($entries as $entry) {
+            $snapshotModel::query()->create(attributes: [
+                'board' => $name,
+                $userForeignKey => $entry->user->getKey(),
+                'rank' => $entry->rank,
+                'score' => $entry->score,
+                'run_at' => $runAt,
+            ]);
+        }
+
+        if ($previousRunAt === null) {
+            return;
+        }
+
+        /** @var Collection<int|string, LeaderboardSnapshot> $previousSnapshots */
+        $previousSnapshots = $snapshotModel::query()
+            ->with(relations: ['user'])
+            ->where(column: 'board', operator: '=', value: $name)
+            ->where(column: 'run_at', operator: '=', value: $previousRunAt)
+            ->get()
+            ->toBase()
+            ->keyBy(keyBy: $userForeignKey);
+
+        $this->dispatchRankEvents(name: $name, entries: $entries, previousSnapshots: $previousSnapshots);
+    }
+
+    /**
+     * @param  Collection<int, LeaderboardEntry>  $entries
+     * @param  Collection<int|string, LeaderboardSnapshot>  $previousSnapshots
+     */
+    private function dispatchRankEvents(string $name, Collection $entries, Collection $previousSnapshots): void
+    {
+        $currentKeys = [];
+
+        foreach ($entries as $entry) {
+            $key = $entry->user->getKey();
+            $currentKeys[] = $key;
+
+            $previous = $previousSnapshots->get(key: $key);
+
+            if (! $previous instanceof Model) {
+                event(new UserEnteredTrackedDepth(user: $entry->user, board: $name, rank: $entry->rank));
+
+                continue;
+            }
+
+            $from = (int) $previous->getAttribute(key: 'rank');
+
+            if ($from !== $entry->rank) {
+                event(new LeaderboardRankChanged(user: $entry->user, board: $name, from: $from, to: $entry->rank));
+            }
+        }
+
+        foreach ($previousSnapshots->except(keys: $currentKeys) as $departed) {
+            event(new UserLeftTrackedDepth(
+                user: $departed->getRelation(relation: 'user'),
+                board: $name,
+                previousRank: (int) $departed->getAttribute(key: 'rank'),
+            ));
+        }
+    }
+}

--- a/src/Commands/SnapshotBoardsCommand.php
+++ b/src/Commands/SnapshotBoardsCommand.php
@@ -15,10 +15,12 @@ use LevelUp\Experience\Models\LeaderboardSnapshot;
 use LevelUp\Experience\Services\LeaderboardService;
 use LevelUp\Experience\Support\LeaderboardEntry;
 
-#[\Illuminate\Console\Attributes\Description('Snapshot the top entries of every declared leaderboard Board, dispatch rank events, and prune old runs.')]
-#[\Illuminate\Console\Attributes\Signature('level-up:snapshot-boards')]
 class SnapshotBoardsCommand extends Command
 {
+    protected $signature = 'level-up:snapshot-boards';
+
+    protected $description = 'Snapshot the top entries of every declared leaderboard Board, dispatch rank events, and prune old runs.';
+
     public function handle(LeaderboardService $leaderboard): int
     {
         $boards = config()->array(key: 'level-up.leaderboard.boards');

--- a/src/Events/LeaderboardRankChanged.php
+++ b/src/Events/LeaderboardRankChanged.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LevelUp\Experience\Events;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Events\Dispatchable;
+
+class LeaderboardRankChanged
+{
+    use Dispatchable;
+
+    public function __construct(
+        public readonly Model $user,
+        public readonly string $board,
+        public readonly int $from,
+        public readonly int $to,
+    ) {}
+}

--- a/src/Events/UserEnteredTrackedDepth.php
+++ b/src/Events/UserEnteredTrackedDepth.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LevelUp\Experience\Events;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Events\Dispatchable;
+
+class UserEnteredTrackedDepth
+{
+    use Dispatchable;
+
+    public function __construct(
+        public readonly Model $user,
+        public readonly string $board,
+        public readonly int $rank,
+    ) {}
+}

--- a/src/Events/UserLeftTrackedDepth.php
+++ b/src/Events/UserLeftTrackedDepth.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LevelUp\Experience\Events;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Events\Dispatchable;
+
+class UserLeftTrackedDepth
+{
+    use Dispatchable;
+
+    public function __construct(
+        public readonly Model $user,
+        public readonly string $board,
+        public readonly int $previousRank,
+    ) {}
+}

--- a/src/LevelUpServiceProvider.php
+++ b/src/LevelUpServiceProvider.php
@@ -7,6 +7,7 @@ namespace LevelUp\Experience;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\ForeignIdColumnDefinition;
 use InvalidArgumentException;
+use LevelUp\Experience\Commands\SnapshotBoardsCommand;
 use LevelUp\Experience\Providers\EventServiceProvider;
 use LevelUp\Experience\Services\LeaderboardService;
 use Spatie\LaravelPackageTools\Package;
@@ -31,6 +32,7 @@ class LevelUpServiceProvider extends PackageServiceProvider
             'multiplier_tier' => 'multiplier_tier',
             'challenges' => 'challenges',
             'challenge_user' => 'challenge_user',
+            'leaderboard_snapshots' => 'leaderboard_snapshots',
         ];
 
         $resolved = [];
@@ -63,6 +65,7 @@ class LevelUpServiceProvider extends PackageServiceProvider
         $package
             ->name(name: 'level-up')
             ->hasConfigFile()
+            ->hasCommand(commandClassName: SnapshotBoardsCommand::class)
             ->hasMigrations([
                 'create_levels_table',
                 'create_experiences_table',
@@ -86,6 +89,7 @@ class LevelUpServiceProvider extends PackageServiceProvider
                 'add_multipliers_column_to_experience_audits_table',
                 'create_challenges_table',
                 'create_challenge_user_table',
+                'create_leaderboard_snapshots_table',
             ]);
     }
 
@@ -95,6 +99,7 @@ class LevelUpServiceProvider extends PackageServiceProvider
 
         $this->app->register(provider: EventServiceProvider::class);
         $this->app->singleton(abstract: 'leaderboard', concrete: fn (): LeaderboardService => new LeaderboardService());
+        $this->app->alias(abstract: 'leaderboard', alias: LeaderboardService::class);
     }
 
     protected function registerEntityKeyMacros(): void

--- a/src/Models/LeaderboardSnapshot.php
+++ b/src/Models/LeaderboardSnapshot.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LevelUp\Experience\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use LevelUp\Experience\Concerns\HasConfigurableIds;
+use LevelUp\Experience\Concerns\ResolvesConfiguredTable;
+
+/**
+ * @property int|string $id
+ * @property string $board
+ * @property int|string $user_id
+ * @property int $rank
+ * @property float $score
+ * @property \Illuminate\Support\Carbon $run_at
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ */
+class LeaderboardSnapshot extends Model
+{
+    use HasConfigurableIds, ResolvesConfiguredTable;
+
+    protected $guarded = [];
+
+    protected $casts = [
+        'rank' => 'integer',
+        'score' => 'float',
+        'run_at' => 'datetime',
+    ];
+
+    /**
+     * @return BelongsTo<Model, $this>
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(config(key: 'level-up.user.model'));
+    }
+
+    protected function configuredTableKey(): string
+    {
+        return 'leaderboard_snapshots';
+    }
+}

--- a/tests/Config/ResolveTablesTest.php
+++ b/tests/Config/ResolveTablesTest.php
@@ -25,6 +25,7 @@ it('returns defaults when no prefix or overrides are set', function (): void {
         'multiplier_tier' => 'multiplier_tier',
         'challenges' => 'challenges',
         'challenge_user' => 'challenge_user',
+        'leaderboard_snapshots' => 'leaderboard_snapshots',
     ]);
 });
 

--- a/tests/Migrations/TablePrefixIntegrationTest.php
+++ b/tests/Migrations/TablePrefixIntegrationTest.php
@@ -31,6 +31,7 @@ class TablePrefixIntegrationTest extends TestCase
         $this->assertTrue(Schema::hasTable('pfx_multiplier_tier'));
         $this->assertTrue(Schema::hasTable('pfx_challenges'));
         $this->assertTrue(Schema::hasTable('pfx_challenge_user'));
+        $this->assertTrue(Schema::hasTable('pfx_leaderboard_snapshots'));
     }
 
     public function test_explicit_override_escapes_the_prefix(): void

--- a/tests/Services/LeaderboardSnapshotsTest.php
+++ b/tests/Services/LeaderboardSnapshotsTest.php
@@ -1,0 +1,346 @@
+<?php
+
+declare(strict_types=1);
+
+uses()->group('leaderboard');
+
+use Illuminate\Support\Facades\Date;
+use Illuminate\Support\Facades\Event;
+use LevelUp\Experience\Events\LeaderboardRankChanged;
+use LevelUp\Experience\Events\UserEnteredTrackedDepth;
+use LevelUp\Experience\Events\UserLeftTrackedDepth;
+use LevelUp\Experience\Models\Experience;
+use LevelUp\Experience\Models\LeaderboardSnapshot;
+use LevelUp\Experience\Tests\Fixtures\User;
+
+beforeEach(function (): void {
+    config(['level-up.user.model' => User::class]);
+    config(['level-up.multiplier.enabled' => false]);
+});
+
+it(description: 'snapshots the top entries of a declared Board', closure: function (): void {
+    config(['level-up.leaderboard.boards' => [
+        'xp-board' => ['metric' => 'xp'],
+    ]]);
+
+    $this->travelTo(Date::parse(time: '2026-06-01 06:00:00'));
+
+    $leader = tap(User::newFactory()->create())->addPoints(300);
+    $runnerUp = tap(User::newFactory()->create())->addPoints(100);
+
+    $this->artisan(command: 'level-up:snapshot-boards')->assertSuccessful();
+
+    $snapshots = LeaderboardSnapshot::query()->orderBy(column: 'rank')->get();
+
+    expect($snapshots)->toHaveCount(count: 2)
+        ->and($snapshots->first()->board)->toBe(expected: 'xp-board')
+        ->and($snapshots->first()->user_id)->toEqual($leader->id)
+        ->and($snapshots->first()->rank)->toBe(expected: 1)
+        ->and($snapshots->first()->score)->toBe(expected: 300.0)
+        ->and($snapshots->first()->run_at)->toBeCarbon(expected: '2026-06-01 06:00:00')
+        ->and($snapshots->last()->user_id)->toEqual($runnerUp->id)
+        ->and($snapshots->last()->rank)->toBe(expected: 2);
+});
+
+it(description: 'stores no snapshot rows below the default tracked depth of 100', closure: function (): void {
+    config(['level-up.leaderboard.boards' => [
+        'xp-board' => ['metric' => 'xp'],
+    ]]);
+
+    $users = User::newFactory()->count(count: 101)->create();
+
+    $users->each(function (User $user, int $index): void {
+        Experience::query()->create(attributes: [
+            'user_id' => $user->id,
+            'level_id' => 1,
+            'experience_points' => 1000 - $index,
+        ]);
+    });
+
+    $this->artisan(command: 'level-up:snapshot-boards')->assertSuccessful();
+
+    $hindmost = $users->last();
+
+    expect(LeaderboardSnapshot::query()->count())->toBe(expected: 100)
+        ->and(LeaderboardSnapshot::query()->where(column: 'user_id', operator: '=', value: $hindmost->id)->exists())->toBeFalse();
+});
+
+it(description: 'bounds the snapshot by a per-Board track_top override', closure: function (): void {
+    config(['level-up.leaderboard.boards' => [
+        'xp-board' => ['metric' => 'xp', 'track_top' => 2],
+    ]]);
+
+    tap(User::newFactory()->create())->addPoints(300);
+    tap(User::newFactory()->create())->addPoints(200);
+    $belowDepth = tap(User::newFactory()->create())->addPoints(100);
+
+    $this->artisan(command: 'level-up:snapshot-boards')->assertSuccessful();
+
+    expect(LeaderboardSnapshot::query()->count())->toBe(expected: 2)
+        ->and(LeaderboardSnapshot::query()->where(column: 'user_id', operator: '=', value: $belowDepth->id)->exists())->toBeFalse();
+});
+
+it(description: 'dispatches rank-changed events with from and to ranks when a second run diffs against the first', closure: function (): void {
+    config(['level-up.leaderboard.boards' => [
+        'xp-board' => ['metric' => 'xp'],
+    ]]);
+
+    $this->travelTo(Date::parse(time: '2026-06-01 06:00:00'));
+
+    $overtaken = tap(User::newFactory()->create())->addPoints(100);
+    $climber = tap(User::newFactory()->create())->addPoints(50);
+
+    $this->artisan(command: 'level-up:snapshot-boards')->assertSuccessful();
+
+    $this->travelTo(Date::parse(time: '2026-06-02 06:00:00'));
+    $climber->addPoints(100);
+
+    Event::fake(eventsToFake: [LeaderboardRankChanged::class]);
+
+    $this->artisan(command: 'level-up:snapshot-boards')->assertSuccessful();
+
+    Event::assertDispatched(
+        event: LeaderboardRankChanged::class,
+        callback: fn (LeaderboardRankChanged $event): bool => $event->user->is(model: $climber)
+            && $event->board === 'xp-board'
+            && $event->from === 2
+            && $event->to === 1,
+    );
+    Event::assertDispatched(
+        event: LeaderboardRankChanged::class,
+        callback: fn (LeaderboardRankChanged $event): bool => $event->user->is(model: $overtaken)
+            && $event->board === 'xp-board'
+            && $event->from === 1
+            && $event->to === 2,
+    );
+    Event::assertDispatchedTimes(event: LeaderboardRankChanged::class, times: 2);
+});
+
+it(description: 'dispatches an entered event when a user breaks into the tracked depth', closure: function (): void {
+    config(['level-up.leaderboard.boards' => [
+        'xp-board' => ['metric' => 'xp', 'track_top' => 2],
+    ]]);
+
+    $this->travelTo(Date::parse(time: '2026-06-01 06:00:00'));
+
+    tap(User::newFactory()->create())->addPoints(300);
+    $displaced = tap(User::newFactory()->create())->addPoints(200);
+    $climber = tap(User::newFactory()->create())->addPoints(100);
+
+    $this->artisan(command: 'level-up:snapshot-boards')->assertSuccessful();
+
+    $this->travelTo(Date::parse(time: '2026-06-02 06:00:00'));
+    $climber->addPoints(150);
+
+    Event::fake(eventsToFake: [UserEnteredTrackedDepth::class, UserLeftTrackedDepth::class]);
+
+    $this->artisan(command: 'level-up:snapshot-boards')->assertSuccessful();
+
+    Event::assertDispatched(
+        event: UserEnteredTrackedDepth::class,
+        callback: fn (UserEnteredTrackedDepth $event): bool => $event->user->is(model: $climber)
+            && $event->board === 'xp-board'
+            && $event->rank === 2,
+    );
+    Event::assertDispatchedTimes(event: UserEnteredTrackedDepth::class, times: 1);
+    Event::assertDispatched(
+        event: UserLeftTrackedDepth::class,
+        callback: fn (UserLeftTrackedDepth $event): bool => $event->user->is(model: $displaced)
+            && $event->board === 'xp-board'
+            && $event->previousRank === 2,
+    );
+    Event::assertDispatchedTimes(event: UserLeftTrackedDepth::class, times: 1);
+});
+
+it(description: 'stays silent for rank shuffles below the tracked depth', closure: function (): void {
+    config(['level-up.leaderboard.boards' => [
+        'xp-board' => ['metric' => 'xp', 'track_top' => 2],
+    ]]);
+
+    $this->travelTo(Date::parse(time: '2026-06-01 06:00:00'));
+
+    tap(User::newFactory()->create())->addPoints(300);
+    tap(User::newFactory()->create())->addPoints(200);
+    $midTable = tap(User::newFactory()->create())->addPoints(100);
+    tap(User::newFactory()->create())->addPoints(50);
+
+    $this->artisan(command: 'level-up:snapshot-boards')->assertSuccessful();
+
+    $this->travelTo(Date::parse(time: '2026-06-02 06:00:00'));
+    $midTable->addPoints(20);
+
+    Event::fake(eventsToFake: [LeaderboardRankChanged::class, UserEnteredTrackedDepth::class, UserLeftTrackedDepth::class]);
+
+    $this->artisan(command: 'level-up:snapshot-boards')->assertSuccessful();
+
+    Event::assertNotDispatched(event: LeaderboardRankChanged::class);
+    Event::assertNotDispatched(event: UserEnteredTrackedDepth::class);
+    Event::assertNotDispatched(event: UserLeftTrackedDepth::class);
+});
+
+it(description: 'dispatches nothing when a run finds no rank movement', closure: function (): void {
+    config(['level-up.leaderboard.boards' => [
+        'xp-board' => ['metric' => 'xp'],
+    ]]);
+
+    $this->travelTo(Date::parse(time: '2026-06-01 06:00:00'));
+
+    tap(User::newFactory()->create())->addPoints(300);
+    tap(User::newFactory()->create())->addPoints(100);
+
+    $this->artisan(command: 'level-up:snapshot-boards')->assertSuccessful();
+
+    $this->travelTo(Date::parse(time: '2026-06-02 06:00:00'));
+
+    Event::fake(eventsToFake: [LeaderboardRankChanged::class, UserEnteredTrackedDepth::class, UserLeftTrackedDepth::class]);
+
+    $this->artisan(command: 'level-up:snapshot-boards')->assertSuccessful();
+
+    Event::assertNotDispatched(event: LeaderboardRankChanged::class);
+    Event::assertNotDispatched(event: UserEnteredTrackedDepth::class);
+    Event::assertNotDispatched(event: UserLeftTrackedDepth::class);
+});
+
+it(description: 'prunes snapshot runs older than the configured retention', closure: function (): void {
+    config(['level-up.leaderboard.boards' => [
+        'xp-board' => ['metric' => 'xp'],
+    ]]);
+
+    tap(User::newFactory()->create())->addPoints(300);
+
+    $this->travelTo(Date::parse(time: '2026-06-01 06:00:00'));
+    $this->artisan(command: 'level-up:snapshot-boards')->assertSuccessful();
+
+    $this->travelTo(Date::parse(time: '2026-06-16 06:00:00'));
+    $this->artisan(command: 'level-up:snapshot-boards')->assertSuccessful();
+
+    $this->travelTo(Date::parse(time: '2026-07-02 06:00:00'));
+    $this->artisan(command: 'level-up:snapshot-boards')->assertSuccessful();
+
+    $remainingRuns = LeaderboardSnapshot::query()->pluck(column: 'run_at')->map(fn ($runAt): string => $runAt->format('Y-m-d H:i:s'));
+
+    expect($remainingRuns->all())->toBe(['2026-06-16 06:00:00', '2026-07-02 06:00:00']);
+});
+
+it(description: 'respects a custom retention_days config when pruning', closure: function (): void {
+    config(['level-up.leaderboard.boards' => [
+        'xp-board' => ['metric' => 'xp'],
+    ]]);
+    config(['level-up.leaderboard.snapshots.retention_days' => 7]);
+
+    tap(User::newFactory()->create())->addPoints(300);
+
+    $this->travelTo(Date::parse(time: '2026-06-01 06:00:00'));
+    $this->artisan(command: 'level-up:snapshot-boards')->assertSuccessful();
+
+    $this->travelTo(Date::parse(time: '2026-06-09 06:00:00'));
+    $this->artisan(command: 'level-up:snapshot-boards')->assertSuccessful();
+
+    $remainingRuns = LeaderboardSnapshot::query()->pluck(column: 'run_at')->map(fn ($runAt): string => $runAt->format('Y-m-d H:i:s'));
+
+    expect($remainingRuns->all())->toBe(['2026-06-09 06:00:00']);
+});
+
+it(description: 'dispatches nothing on the first run of a Board because there is no previous run to diff', closure: function (): void {
+    config(['level-up.leaderboard.boards' => [
+        'xp-board' => ['metric' => 'xp'],
+    ]]);
+
+    tap(User::newFactory()->create())->addPoints(300);
+    tap(User::newFactory()->create())->addPoints(100);
+
+    Event::fake(eventsToFake: [LeaderboardRankChanged::class, UserEnteredTrackedDepth::class, UserLeftTrackedDepth::class]);
+
+    $this->artisan(command: 'level-up:snapshot-boards')->assertSuccessful();
+
+    expect(LeaderboardSnapshot::query()->count())->toBe(expected: 2);
+
+    Event::assertNotDispatched(event: LeaderboardRankChanged::class);
+    Event::assertNotDispatched(event: UserEnteredTrackedDepth::class);
+    Event::assertNotDispatched(event: UserLeftTrackedDepth::class);
+});
+
+it(description: 'diffs each declared Board in isolation', closure: function (): void {
+    config(['level-up.leaderboard.boards' => [
+        'xp-board' => ['metric' => 'xp'],
+        'level-board' => ['metric' => 'level'],
+    ]]);
+
+    $this->travelTo(Date::parse(time: '2026-06-01 06:00:00'));
+
+    $overtaken = tap(User::newFactory()->create())->addPoints(200);
+    $climber = tap(User::newFactory()->create())->addPoints(180);
+
+    $this->artisan(command: 'level-up:snapshot-boards')->assertSuccessful();
+
+    $this->travelTo(Date::parse(time: '2026-06-02 06:00:00'));
+    $climber->addPoints(30);
+
+    Event::fake(eventsToFake: [LeaderboardRankChanged::class, UserEnteredTrackedDepth::class, UserLeftTrackedDepth::class]);
+
+    $this->artisan(command: 'level-up:snapshot-boards')->assertSuccessful();
+
+    expect(LeaderboardSnapshot::query()->where(column: 'board', operator: '=', value: 'xp-board')->count())->toBe(expected: 4)
+        ->and(LeaderboardSnapshot::query()->where(column: 'board', operator: '=', value: 'level-board')->count())->toBe(expected: 4);
+
+    Event::assertDispatched(
+        event: LeaderboardRankChanged::class,
+        callback: fn (LeaderboardRankChanged $event): bool => $event->board === 'xp-board',
+    );
+    Event::assertNotDispatched(
+        event: LeaderboardRankChanged::class,
+        callback: fn (LeaderboardRankChanged $event): bool => $event->board === 'level-board',
+    );
+    Event::assertNotDispatched(event: UserEnteredTrackedDepth::class);
+    Event::assertNotDispatched(event: UserLeftTrackedDepth::class);
+});
+
+it(description: 'replaces the rows of a same-instant run instead of duplicating them', closure: function (): void {
+    config(['level-up.leaderboard.boards' => [
+        'xp-board' => ['metric' => 'xp'],
+    ]]);
+
+    $this->travelTo(Date::parse(time: '2026-06-01 06:00:00'));
+
+    tap(User::newFactory()->create())->addPoints(300);
+    tap(User::newFactory()->create())->addPoints(100);
+
+    $this->artisan(command: 'level-up:snapshot-boards')->assertSuccessful();
+    $this->artisan(command: 'level-up:snapshot-boards')->assertSuccessful();
+
+    $snapshots = LeaderboardSnapshot::query()->orderBy(column: 'rank')->get();
+
+    expect($snapshots)->toHaveCount(count: 2)
+        ->and($snapshots->map(fn (LeaderboardSnapshot $snapshot): int => $snapshot->rank)->all())->toBe([1, 2]);
+});
+
+it(description: 'reports only real movement when a tie breaks', closure: function (): void {
+    config(['level-up.leaderboard.boards' => [
+        'xp-board' => ['metric' => 'xp'],
+    ]]);
+
+    $this->travelTo(Date::parse(time: '2026-06-01 06:00:00'));
+
+    $slipped = tap(User::newFactory()->create())->addPoints(100);
+    $tieBreaker = tap(User::newFactory()->create())->addPoints(100);
+    tap(User::newFactory()->create())->addPoints(90);
+
+    $this->artisan(command: 'level-up:snapshot-boards')->assertSuccessful();
+
+    $this->travelTo(Date::parse(time: '2026-06-02 06:00:00'));
+    $tieBreaker->addPoints(50);
+
+    Event::fake(eventsToFake: [LeaderboardRankChanged::class, UserEnteredTrackedDepth::class, UserLeftTrackedDepth::class]);
+
+    $this->artisan(command: 'level-up:snapshot-boards')->assertSuccessful();
+
+    Event::assertDispatched(
+        event: LeaderboardRankChanged::class,
+        callback: fn (LeaderboardRankChanged $event): bool => $event->user->is(model: $slipped)
+            && $event->from === 1
+            && $event->to === 2,
+    );
+    Event::assertDispatchedTimes(event: LeaderboardRankChanged::class, times: 1);
+    Event::assertNotDispatched(event: UserEnteredTrackedDepth::class);
+    Event::assertNotDispatched(event: UserLeftTrackedDepth::class);
+});

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -74,6 +74,7 @@ class TestCase extends Orchestra
             'add_multipliers_column_to_experience_audits_table',
             'create_challenges_table',
             'create_challenge_user_table',
+            'create_leaderboard_snapshots_table',
         ];
 
         foreach ($migrations as $migrationFile) {


### PR DESCRIPTION
## What's new

Your leaderboards now have a memory. A **Snapshot** persists a Board's top entries at a point in time, and diffing consecutive snapshots produces the rank *deltas* a live query can never compute — so you can finally tell a user "you climbed from #5 to #2 this week".

### The `level-up:snapshot-boards` command

One command snapshots every Board declared in `level-up.leaderboard.boards`, diffs each against its previous run, dispatches rank events, and prunes old runs. You schedule it — the package never auto-registers scheduler entries:

```php
// routes/console.php
use Illuminate\Support\Facades\Schedule;

Schedule::command('level-up:snapshot-boards')->hourly();
```

### Tracked depth

Each run stores a Board's top **tracked depth** entries — `track_top` in the board declaration, default 100:

```php
'boards' => [
    'weekly-xp' => ['metric' => 'xp', 'period' => 'week', 'track_top' => 50],
],
```

Below the tracked depth a Board is **silent by design**: no snapshot rows, no events. Mid-table shuffles ("#6,389 → #6,412") never flood your queue — raise `track_top` if you want deeper tracking and are happy to own the cost.

### Events

| Event | Properties | When |
|-------|-----------|------|
| `LeaderboardRankChanged` | `Model $user`, `string $board`, `int $from`, `int $to` | A user moved rank within the tracked depth |
| `UserEnteredTrackedDepth` | `Model $user`, `string $board`, `int $rank` | A user broke into the tracked depth |
| `UserLeftTrackedDepth` | `Model $user`, `string $board`, `int $previousRank` | A user dropped out of the tracked depth |

Listen for these to send notifications, drive `leaderboard_rank` challenge conditions, or power promotion/relegation cutoffs.

### Semantics worth knowing

- **First run is silent** — events are deltas between runs; the first run just writes the baseline.
- **Re-runs are safe** — a run is identified by its timestamp, so re-running within the same instant replaces that run's rows instead of duplicating them, and recomputes the same diff.
- **Snapshots are not a cache** — `rankOf()` and `around()` still compute fresh, for any user at any depth.
- **Retention** — the same command prunes runs older than `level-up.leaderboard.snapshots.retention_days` (default 30).

## Breaking changes / upgrade notes

- New migration: `create_leaderboard_snapshots_table` — run `php artisan migrate` after upgrading. The table respects your configured `table_prefix`/`tables` overrides and user foreign-key type (`bigint`/`uuid`/`ulid`).
- New config keys: `track_top` per board declaration, `level-up.leaderboard.snapshots.retention_days`, `level-up.tables.leaderboard_snapshots`, and `level-up.models.leaderboard_snapshot`. All have defaults; existing published configs keep working.

Stacked on #166 (named Boards) — diff shows only this slice once #166 merges.

Closes #154