### PR TITLE
feat(v3): finish-top-N leaderboard challenges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1145,7 +1145,34 @@ Challenge::create([
 | `achievement_earned` | `achievement_id` | User has the achievement |
 | `streak_count` | `activity`, `count` | Current streak count for the activity |
 | `tier_reached` | `tier` | User is at or above the named tier |
+| `leaderboard_rank` | `board`, `rank` | User's rank on the named Board is at or above the target |
 | `custom` | `class` | Your own class implementing `ChallengeCondition` |
+
+### Leaderboard Rank Conditions
+
+The `leaderboard_rank` condition is "finish top N on a named Board" — it is met when the user's rank on the Board, as recorded by the latest snapshot run, is at or above the target (`rank <= N`):
+
+```php
+Challenge::create([
+    'name' => 'Podium Finish',
+    'description' => 'Crack the top 3 on the weekly XP board.',
+    'conditions' => [
+        ['type' => 'leaderboard_rank', 'board' => 'weekly-xp', 'rank' => 3],
+    ],
+    'rewards' => [
+        ['type' => 'points', 'amount' => 500],
+    ],
+    'auto_enroll' => true,
+]);
+```
+
+> [!IMPORTANT]
+> This condition only progresses when `level-up:snapshot-boards` runs — schedule it (see [Snapshots and rank events](#snapshots-and-rank-events)). Progress is evaluated on the rank events the snapshot run dispatches, and the rank is read from the run's snapshot rows, so a board that is never snapshotted never satisfies the condition.
+
+Validation on challenge creation is strict, so a misconfigured condition fails loudly instead of silently never completing:
+
+- `board` must be a Board declared in `level-up.leaderboard.boards`.
+- `rank` must be a positive integer within the Board's tracked depth (`track_top`, default 100). A condition targeting rank 150 on a board tracking the top 100 is rejected — below the tracked depth the board is silent, so the condition could never be met. Raise the Board's `track_top` if you need deeper targets.
 
 ### Reward Types
 

--- a/README.md
+++ b/README.md
@@ -754,6 +754,56 @@ Declarations are validated loudly at resolution rather than producing a silently
 
 Why declare a board instead of just querying? Boards are the leaderboards the package will **track over time** — snapshots, rank-change events, and leagues (arriving in later releases) apply only to declared Boards. Ad-hoc queries stay exactly what they are: composed, executed, forgotten. Declare no boards and none of that machinery activates.
 
+### Snapshots and rank events
+
+A **Snapshot** is the leaderboard's memory: a persisted record of a Board's top entries at a point in time. Diffing consecutive snapshots produces rank *deltas* — "you climbed from #5 to #2" — which a stateless query can never compute. The `level-up:snapshot-boards` command writes one snapshot run per declared Board, diffs it against the previous run, dispatches rank events, and prunes old runs.
+
+Schedule the command from your application — the package never auto-registers scheduler entries:
+
+```php
+// routes/console.php
+use Illuminate\Support\Facades\Schedule;
+
+Schedule::command('level-up:snapshot-boards')->hourly();
+```
+
+Each run stores the top **tracked depth** entries per Board — `track_top` in the board declaration, default 100:
+
+```php
+'boards' => [
+    'weekly-xp' => ['metric' => 'xp', 'period' => 'week', 'track_top' => 50],
+],
+```
+
+Diffing two runs dispatches three events, each carrying the board name:
+
+| Event | Properties | When |
+|-------|-----------|------|
+| `LeaderboardRankChanged` | `Model $user`, `string $board`, `int $from`, `int $to` | A user moved rank within the tracked depth |
+| `UserEnteredTrackedDepth` | `Model $user`, `string $board`, `int $rank` | A user broke into the tracked depth |
+| `UserLeftTrackedDepth` | `Model $user`, `string $board`, `int $previousRank` | A user dropped out of the tracked depth |
+
+Below the tracked depth a Board is **silent by design**: no snapshot rows, no events. "You dropped from #6,389 to #6,412" is not a thing the package emits — raise `track_top` if you want deeper tracking and are happy to own the cost. Ties use the same competition semantics as live queries, so a tie breaking only events the users whose rank number actually changed.
+
+Two semantics worth knowing:
+
+- **The first run of a Board is silent.** Events are deltas between runs; with no previous run there is no delta — the first run just writes the baseline snapshot.
+- **Re-running within the same instant replaces that run.** A run is identified by its timestamp (to the second), so an immediate re-run overwrites the same run's rows instead of duplicating them, and recomputes the same diff against the run before it.
+
+Old runs are pruned by the same command per `level-up.leaderboard.snapshots.retention_days` (default 30):
+
+```php
+'leaderboard' => [
+    // ...
+    'snapshots' => [
+        'retention_days' => 30,
+    ],
+],
+```
+
+> [!NOTE]
+> Snapshots are **not a cache** for live queries — `rankOf()` and `around()` always compute fresh, for any user at any depth. Snapshots exist solely to remember past runs so rank deltas can be evented.
+
 ### Custom metrics
 
 Rank by anything you can express as a SQL score: implement `LevelUp\Experience\Contracts\RankingMetric` — a stable `key()`, a `label()`, an `enabled()` check, a `constrain()` that scopes the user query to eligible users, and a `scoreExpression()` subquery yielding one numeric score per user — then register the class in `level-up.leaderboard.metrics`.

--- a/config/level-up.php
+++ b/config/level-up.php
@@ -19,6 +19,7 @@ return [
         'multiplier_tier' => LevelUp\Experience\Models\Pivots\MultiplierTier::class,
         'challenge' => LevelUp\Experience\Models\Challenge::class,
         'challenge_user' => LevelUp\Experience\Models\Pivots\ChallengeUser::class,
+        'leaderboard_snapshot' => LevelUp\Experience\Models\LeaderboardSnapshot::class,
     ],
 
     /*
@@ -98,6 +99,7 @@ return [
         'multiplier_tier' => 'multiplier_tier',
         'challenges' => 'challenges',
         'challenge_user' => 'challenge_user',
+        'leaderboard_snapshots' => 'leaderboard_snapshots',
     ],
 
     /*
@@ -118,8 +120,13 @@ return [
     | 'boards' declares named Boards — leaderboards the package can
     | track over time. Each entry maps a board name to a 'metric'
     | (required registry key), an optional 'period' ('day', 'week',
-    | or 'month'), and an optional 'tier' (a tier name). For example:
+    | or 'month'), an optional 'tier' (a tier name), and an optional
+    | 'track_top' (the tracked depth — how many top entries the
+    | snapshot run stores and events, default 100). For example:
     | 'weekly-xp' => ['metric' => 'xp', 'period' => 'week'].
+    |
+    | 'snapshots.retention_days' controls how long snapshot runs are
+    | kept; the level-up:snapshot-boards command prunes older runs.
     |
     */
     'leaderboard' => [
@@ -132,6 +139,9 @@ return [
             'challenges' => LevelUp\Experience\Metrics\ChallengeMetric::class,
         ],
         'boards' => [],
+        'snapshots' => [
+            'retention_days' => 30,
+        ],
         'week_starts_on' => Carbon\CarbonInterface::MONDAY,
         'timezone' => null,
     ],

--- a/database/migrations/create_leaderboard_snapshots_table.php.stub
+++ b/database/migrations/create_leaderboard_snapshots_table.php.stub
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create(config('level-up.tables.leaderboard_snapshots'), function (Blueprint $table) {
+            $table->entityId();
+            $table->string(column: 'board');
+            $table->userForeignId()->constrained(config('level-up.user.users_table'));
+            $table->unsignedInteger(column: 'rank');
+            $table->double(column: 'score');
+            $table->timestamp(column: 'run_at');
+            $table->timestamps();
+
+            $table->index(['board', 'run_at']);
+            $table->index('run_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists(config('level-up.tables.leaderboard_snapshots'));
+    }
+};

--- a/rector.php
+++ b/rector.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 use Rector\Config\RectorConfig;
 use Rector\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector;
 use RectorLaravel\Rector\Class_\AddHasFactoryToModelsRector;
+use RectorLaravel\Rector\Class_\DescriptionPropertyToDescriptionAttributeRector;
+use RectorLaravel\Rector\Class_\SignaturePropertyToSignatureAttributeRector;
 use RectorLaravel\Rector\Class_\TablePropertyToTableAttributeRector;
 use RectorLaravel\Rector\ClassMethod\MakeModelAttributesAndScopesProtectedRector;
 use RectorLaravel\Rector\FuncCall\RemoveDumpDataDeadCodeRector;
@@ -23,6 +25,8 @@ return RectorConfig::configure()
         AddHasFactoryToModelsRector::class,
         MakeModelAttributesAndScopesProtectedRector::class,
         TablePropertyToTableAttributeRector::class,
+        DescriptionPropertyToDescriptionAttributeRector::class,
+        SignaturePropertyToSignatureAttributeRector::class,
     ])
     ->withPreparedSets(
         deadCode: true,

--- a/resources/boost/skills/level-up-development/SKILL.md
+++ b/resources/boost/skills/level-up-development/SKILL.md
@@ -457,7 +457,7 @@ $histories = StreakHistory::where('user_id', $user->id)->get();
 
 ## Challenges
 
-Challenges are multi-condition goals that users enroll in and complete for rewards. Conditions are evaluated automatically when relevant events fire (points earned, level reached, achievement granted, streak recorded, tier changed).
+Challenges are multi-condition goals that users enroll in and complete for rewards. Conditions are evaluated automatically when relevant events fire (points earned, level reached, achievement granted, streak recorded, tier changed, leaderboard rank moved by a snapshot run).
 
 ### Create a Challenge
 
@@ -487,7 +487,10 @@ Challenge::create([
 | `achievement_earned` | `achievement_id` | User has the achievement |
 | `streak_count` | `activity`, `count` | Current streak count for activity >= value |
 | `tier_reached` | `tier` | User is at or above the named tier |
+| `leaderboard_rank` | `board`, `rank` | Latest snapshot rank on the named Board <= value |
 | `custom` | `class` | Class implementing `ChallengeCondition` interface |
+
+`leaderboard_rank` only progresses when `level-up:snapshot-boards` runs — the host must schedule it. Validation at creation rejects a `board` not declared in `level-up.leaderboard.boards` and a `rank` deeper than the Board's tracked depth (`track_top`, default 100).
 
 ### Reward Types
 

--- a/resources/boost/skills/level-up-development/SKILL.md
+++ b/resources/boost/skills/level-up-development/SKILL.md
@@ -588,18 +588,24 @@ Period boundary config under `level-up.leaderboard`: `week_starts_on` (Carbon da
 
 ### Named Boards
 
-A **Board** is a *declared* leaderboard — a named metric/period(/tier) combination registered in config — as opposed to an ad-hoc fluent query (composed, executed, forgotten). Only declared Boards will be tracked over time (snapshots, rank events, leagues — later releases); declaring none means none of that machinery activates.
+A **Board** is a *declared* leaderboard — a named metric/period(/tier) combination registered in config — as opposed to an ad-hoc fluent query (composed, executed, forgotten). Only declared Boards are tracked over time (snapshots, rank events; leagues — later releases); declaring none means none of that machinery activates.
 
 ```php
 'leaderboard' => [
     'boards' => [
         'weekly-xp' => ['metric' => 'xp', 'period' => 'week'],
-        'gold-race' => ['metric' => 'xp', 'period' => 'week', 'tier' => 'Gold'],
+        'gold-race' => ['metric' => 'xp', 'period' => 'week', 'tier' => 'Gold', 'track_top' => 50],
     ],
 ],
 ```
 
-`metric` is required (a `level-up.leaderboard.metrics` registry key), `period` is optional (`'day'`/`'week'`/`'month'` — the `Period` enum string values), `tier` is optional (a tier name). `Leaderboard::board('weekly-xp')` resolves the declaration into the same fluent query, so all refinements (`restrictTo()`, `rankOf()`, `around()`, `limit:`, `paginate:`) compose on top. Resolution validates loudly: unknown board name → `BoardNotFoundException`; missing or unknown `metric` → `MetricNotFoundException`; `period` on a non-Windowable metric → `MetricNotWindowableException`; invalid `period` string → `ValueError`; nonexistent `tier` name → `ModelNotFoundException`.
+`metric` is required (a `level-up.leaderboard.metrics` registry key), `period` is optional (`'day'`/`'week'`/`'month'` — the `Period` enum string values), `tier` is optional (a tier name), `track_top` is optional (the tracked depth — how many top entries are snapshotted and evented, default 100). `Leaderboard::board('weekly-xp')` resolves the declaration into the same fluent query, so all refinements (`restrictTo()`, `rankOf()`, `around()`, `limit:`, `paginate:`) compose on top. Resolution validates loudly: unknown board name → `BoardNotFoundException`; missing or unknown `metric` → `MetricNotFoundException`; `period` on a non-Windowable metric → `MetricNotWindowableException`; invalid `period` string → `ValueError`; nonexistent `tier` name → `ModelNotFoundException`.
+
+### Snapshots and rank events
+
+A **Snapshot** persists a Board's top `track_top` entries at a point in time (the `leaderboard_snapshots` table, `LeaderboardSnapshot` model: `board`, `user_id`, `rank`, `score`, `run_at`). The `level-up:snapshot-boards` command snapshots every declared Board, diffs against that Board's previous run, dispatches rank events, and prunes runs older than `level-up.leaderboard.snapshots.retention_days` (default 30). The host schedules it (e.g. `Schedule::command('level-up:snapshot-boards')->hourly()` in `routes/console.php`) — the package never auto-registers scheduler entries.
+
+Diff semantics: rank movement within the tracked depth → `LeaderboardRankChanged`; crossing the boundary → `UserEnteredTrackedDepth` / `UserLeftTrackedDepth`; below the tracked depth a Board is **silent by design** (no rows, no events — don't "fix" this). The first run of a Board is silent (no previous run, no delta). A re-run within the same instant replaces that run's rows (a run is identified by `run_at` to the second) and recomputes the same diff. Snapshots are *not* a cache — `rankOf()`/`around()` always compute fresh at any depth.
 
 ## Auditing
 
@@ -650,6 +656,9 @@ AuditType::TierDown; // 'tier_down'
 | `ChallengeCompleted` | `Challenge $challenge`, `Model $user` | Challenge conditions met, rewards dispatched |
 | `ChallengeEnrolled` | `Challenge $challenge`, `Model $user` | User enrolled in challenge |
 | `ChallengeUnenrolled` | `Challenge $challenge`, `Model $user` | User unenrolled from challenge |
+| `LeaderboardRankChanged` | `Model $user`, `string $board`, `int $from`, `int $to` | Snapshot run found rank movement within a Board's tracked depth |
+| `UserEnteredTrackedDepth` | `Model $user`, `string $board`, `int $rank` | Snapshot run found a user broke into a Board's tracked depth |
+| `UserLeftTrackedDepth` | `Model $user`, `string $board`, `int $previousRank` | Snapshot run found a user dropped out of a Board's tracked depth |
 
 ## Common Patterns
 

--- a/src/Commands/SnapshotBoardsCommand.php
+++ b/src/Commands/SnapshotBoardsCommand.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LevelUp\Experience\Commands;
+
+use Carbon\CarbonInterface;
+use Illuminate\Console\Command;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
+use LevelUp\Experience\Events\LeaderboardRankChanged;
+use LevelUp\Experience\Events\UserEnteredTrackedDepth;
+use LevelUp\Experience\Events\UserLeftTrackedDepth;
+use LevelUp\Experience\Models\LeaderboardSnapshot;
+use LevelUp\Experience\Services\LeaderboardService;
+use LevelUp\Experience\Support\LeaderboardEntry;
+
+#[\Illuminate\Console\Attributes\Description('Snapshot the top entries of every declared leaderboard Board, dispatch rank events, and prune old runs.')]
+#[\Illuminate\Console\Attributes\Signature('level-up:snapshot-boards')]
+class SnapshotBoardsCommand extends Command
+{
+    public function handle(LeaderboardService $leaderboard): int
+    {
+        $boards = config()->array(key: 'level-up.leaderboard.boards');
+        $runAt = now();
+
+        foreach (array_keys($boards) as $name) {
+            $this->snapshotBoard(leaderboard: $leaderboard, name: (string) $name, declaration: $boards[$name], runAt: $runAt);
+        }
+
+        $this->pruneStaleRuns(runAt: $runAt);
+
+        return self::SUCCESS;
+    }
+
+    private function pruneStaleRuns(CarbonInterface $runAt): void
+    {
+        $retentionDays = config()->integer(key: 'level-up.leaderboard.snapshots.retention_days', default: 30);
+
+        $snapshotModel = config(key: 'level-up.models.leaderboard_snapshot');
+
+        $snapshotModel::query()
+            ->where(column: 'run_at', operator: '<', value: $runAt->copy()->subDays($retentionDays))
+            ->delete();
+    }
+
+    private function snapshotBoard(LeaderboardService $leaderboard, string $name, mixed $declaration, CarbonInterface $runAt): void
+    {
+        $trackTop = is_array($declaration) && is_int($declaration['track_top'] ?? null) ? $declaration['track_top'] : 100;
+
+        /** @var Collection<int, LeaderboardEntry> $entries */
+        $entries = $leaderboard->board(name: $name)->generate(limit: $trackTop);
+
+        $snapshotModel = config(key: 'level-up.models.leaderboard_snapshot');
+        $userForeignKey = config()->string(key: 'level-up.user.foreign_key');
+
+        $previousRunAt = $snapshotModel::query()
+            ->where(column: 'board', operator: '=', value: $name)
+            ->where(column: 'run_at', operator: '<', value: $runAt)
+            ->max(column: 'run_at');
+
+        $snapshotModel::query()
+            ->where(column: 'board', operator: '=', value: $name)
+            ->where(column: 'run_at', operator: '=', value: $runAt)
+            ->delete();
+
+        foreach ($entries as $entry) {
+            $snapshotModel::query()->create(attributes: [
+                'board' => $name,
+                $userForeignKey => $entry->user->getKey(),
+                'rank' => $entry->rank,
+                'score' => $entry->score,
+                'run_at' => $runAt,
+            ]);
+        }
+
+        if ($previousRunAt === null) {
+            return;
+        }
+
+        /** @var Collection<int|string, LeaderboardSnapshot> $previousSnapshots */
+        $previousSnapshots = $snapshotModel::query()
+            ->with(relations: ['user'])
+            ->where(column: 'board', operator: '=', value: $name)
+            ->where(column: 'run_at', operator: '=', value: $previousRunAt)
+            ->get()
+            ->toBase()
+            ->keyBy(keyBy: $userForeignKey);
+
+        $this->dispatchRankEvents(name: $name, entries: $entries, previousSnapshots: $previousSnapshots);
+    }
+
+    /**
+     * @param  Collection<int, LeaderboardEntry>  $entries
+     * @param  Collection<int|string, LeaderboardSnapshot>  $previousSnapshots
+     */
+    private function dispatchRankEvents(string $name, Collection $entries, Collection $previousSnapshots): void
+    {
+        $currentKeys = [];
+
+        foreach ($entries as $entry) {
+            $key = $entry->user->getKey();
+            $currentKeys[] = $key;
+
+            $previous = $previousSnapshots->get(key: $key);
+
+            if (! $previous instanceof Model) {
+                event(new UserEnteredTrackedDepth(user: $entry->user, board: $name, rank: $entry->rank));
+
+                continue;
+            }
+
+            $from = (int) $previous->getAttribute(key: 'rank');
+
+            if ($from !== $entry->rank) {
+                event(new LeaderboardRankChanged(user: $entry->user, board: $name, from: $from, to: $entry->rank));
+            }
+        }
+
+        foreach ($previousSnapshots->except(keys: $currentKeys) as $departed) {
+            event(new UserLeftTrackedDepth(
+                user: $departed->getRelation(relation: 'user'),
+                board: $name,
+                previousRank: (int) $departed->getAttribute(key: 'rank'),
+            ));
+        }
+    }
+}

--- a/src/Commands/SnapshotBoardsCommand.php
+++ b/src/Commands/SnapshotBoardsCommand.php
@@ -15,10 +15,12 @@ use LevelUp\Experience\Models\LeaderboardSnapshot;
 use LevelUp\Experience\Services\LeaderboardService;
 use LevelUp\Experience\Support\LeaderboardEntry;
 
-#[\Illuminate\Console\Attributes\Description('Snapshot the top entries of every declared leaderboard Board, dispatch rank events, and prune old runs.')]
-#[\Illuminate\Console\Attributes\Signature('level-up:snapshot-boards')]
 class SnapshotBoardsCommand extends Command
 {
+    protected $signature = 'level-up:snapshot-boards';
+
+    protected $description = 'Snapshot the top entries of every declared leaderboard Board, dispatch rank events, and prune old runs.';
+
     public function handle(LeaderboardService $leaderboard): int
     {
         $boards = config()->array(key: 'level-up.leaderboard.boards');

--- a/src/Events/LeaderboardRankChanged.php
+++ b/src/Events/LeaderboardRankChanged.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LevelUp\Experience\Events;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Events\Dispatchable;
+
+class LeaderboardRankChanged
+{
+    use Dispatchable;
+
+    public function __construct(
+        public readonly Model $user,
+        public readonly string $board,
+        public readonly int $from,
+        public readonly int $to,
+    ) {}
+}

--- a/src/Events/UserEnteredTrackedDepth.php
+++ b/src/Events/UserEnteredTrackedDepth.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LevelUp\Experience\Events;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Events\Dispatchable;
+
+class UserEnteredTrackedDepth
+{
+    use Dispatchable;
+
+    public function __construct(
+        public readonly Model $user,
+        public readonly string $board,
+        public readonly int $rank,
+    ) {}
+}

--- a/src/Events/UserLeftTrackedDepth.php
+++ b/src/Events/UserLeftTrackedDepth.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LevelUp\Experience\Events;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Events\Dispatchable;
+
+class UserLeftTrackedDepth
+{
+    use Dispatchable;
+
+    public function __construct(
+        public readonly Model $user,
+        public readonly string $board,
+        public readonly int $previousRank,
+    ) {}
+}

--- a/src/LevelUpServiceProvider.php
+++ b/src/LevelUpServiceProvider.php
@@ -7,6 +7,7 @@ namespace LevelUp\Experience;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\ForeignIdColumnDefinition;
 use InvalidArgumentException;
+use LevelUp\Experience\Commands\SnapshotBoardsCommand;
 use LevelUp\Experience\Providers\EventServiceProvider;
 use LevelUp\Experience\Services\LeaderboardService;
 use Spatie\LaravelPackageTools\Package;
@@ -31,6 +32,7 @@ class LevelUpServiceProvider extends PackageServiceProvider
             'multiplier_tier' => 'multiplier_tier',
             'challenges' => 'challenges',
             'challenge_user' => 'challenge_user',
+            'leaderboard_snapshots' => 'leaderboard_snapshots',
         ];
 
         $resolved = [];
@@ -63,6 +65,7 @@ class LevelUpServiceProvider extends PackageServiceProvider
         $package
             ->name(name: 'level-up')
             ->hasConfigFile()
+            ->hasCommand(commandClassName: SnapshotBoardsCommand::class)
             ->hasMigrations([
                 'create_levels_table',
                 'create_experiences_table',
@@ -86,6 +89,7 @@ class LevelUpServiceProvider extends PackageServiceProvider
                 'add_multipliers_column_to_experience_audits_table',
                 'create_challenges_table',
                 'create_challenge_user_table',
+                'create_leaderboard_snapshots_table',
             ]);
     }
 
@@ -95,6 +99,7 @@ class LevelUpServiceProvider extends PackageServiceProvider
 
         $this->app->register(provider: EventServiceProvider::class);
         $this->app->singleton(abstract: 'leaderboard', concrete: fn (): LeaderboardService => new LeaderboardService());
+        $this->app->alias(abstract: 'leaderboard', alias: LeaderboardService::class);
     }
 
     protected function registerEntityKeyMacros(): void

--- a/src/Listeners/ChallengeProgressListener.php
+++ b/src/Listeners/ChallengeProgressListener.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace LevelUp\Experience\Listeners;
 
 use LevelUp\Experience\Events\AchievementAwarded;
+use LevelUp\Experience\Events\LeaderboardRankChanged;
 use LevelUp\Experience\Events\PointsIncreased;
 use LevelUp\Experience\Events\StreakIncreased;
+use LevelUp\Experience\Events\UserEnteredTrackedDepth;
 use LevelUp\Experience\Events\UserLevelledUp;
 use LevelUp\Experience\Events\UserTierUpdated;
 use LevelUp\Experience\Services\ChallengeService;
@@ -14,7 +16,7 @@ use Throwable;
 
 class ChallengeProgressListener
 {
-    public function __invoke(PointsIncreased|AchievementAwarded|StreakIncreased|UserLevelledUp|UserTierUpdated $event): void
+    public function __invoke(PointsIncreased|AchievementAwarded|StreakIncreased|UserLevelledUp|UserTierUpdated|LeaderboardRankChanged|UserEnteredTrackedDepth $event): void
     {
         if (! config()->boolean(key: 'level-up.challenges.enabled')) {
             return;
@@ -30,7 +32,7 @@ class ChallengeProgressListener
         }
     }
 
-    protected function mapEventToConditionTypes(PointsIncreased|AchievementAwarded|StreakIncreased|UserLevelledUp|UserTierUpdated $event): array
+    protected function mapEventToConditionTypes(PointsIncreased|AchievementAwarded|StreakIncreased|UserLevelledUp|UserTierUpdated|LeaderboardRankChanged|UserEnteredTrackedDepth $event): array
     {
         $types = match (true) {
             $event instanceof PointsIncreased => ['points_earned'],
@@ -38,6 +40,7 @@ class ChallengeProgressListener
             $event instanceof AchievementAwarded => ['achievement_earned'],
             $event instanceof StreakIncreased => ['streak_count'],
             $event instanceof UserTierUpdated => ['tier_reached'],
+            $event instanceof LeaderboardRankChanged, $event instanceof UserEnteredTrackedDepth => ['leaderboard_rank'],
         };
 
         $types[] = 'custom';

--- a/src/Models/Challenge.php
+++ b/src/Models/Challenge.php
@@ -51,6 +51,7 @@ class Challenge extends Model
         'achievement_earned' => ['achievement_id'],
         'streak_count' => ['activity', 'count'],
         'tier_reached' => ['tier'],
+        'leaderboard_rank' => ['board', 'rank'],
         'custom' => ['class'],
     ];
 
@@ -151,6 +152,33 @@ class Challenge extends Model
                 $class = $entry['class'];
                 throw_if(! class_exists($class) || ! is_subclass_of($class, ChallengeCondition::class), InvalidArgumentException::class, "{$label} at index {$index}: class '{$class}' must exist and implement ChallengeCondition.");
             }
+
+            if ($type === 'leaderboard_rank') {
+                $this->validateLeaderboardRankEntry(entry: $entry, index: $index, label: $label);
+            }
         }
+    }
+
+    /**
+     * @param  array<string, mixed>  $entry
+     */
+    private function validateLeaderboardRankEntry(array $entry, int $index, string $label): void
+    {
+        $board = $entry['board'];
+
+        throw_unless(is_string($board) && $board !== '', InvalidArgumentException::class, "{$label} at index {$index}: 'board' must be a board name string.");
+
+        $boards = config()->array(key: 'level-up.leaderboard.boards');
+
+        throw_unless(array_key_exists($board, $boards), InvalidArgumentException::class, "{$label} at index {$index}: board '{$board}' is not declared in level-up.leaderboard.boards.");
+
+        $rank = $entry['rank'];
+
+        throw_unless(is_int($rank) && $rank >= 1, InvalidArgumentException::class, "{$label} at index {$index}: 'rank' must be a positive integer.");
+
+        $declaration = $boards[$board];
+        $trackTop = is_array($declaration) && is_int($declaration['track_top'] ?? null) ? $declaration['track_top'] : 100;
+
+        throw_if($rank > $trackTop, InvalidArgumentException::class, "{$label} at index {$index}: rank {$rank} is deeper than board '{$board}' tracked depth ({$trackTop}). Raise the board's track_top or target a shallower rank.");
     }
 }

--- a/src/Models/LeaderboardSnapshot.php
+++ b/src/Models/LeaderboardSnapshot.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LevelUp\Experience\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use LevelUp\Experience\Concerns\HasConfigurableIds;
+use LevelUp\Experience\Concerns\ResolvesConfiguredTable;
+
+/**
+ * @property int|string $id
+ * @property string $board
+ * @property int|string $user_id
+ * @property int $rank
+ * @property float $score
+ * @property \Illuminate\Support\Carbon $run_at
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ */
+class LeaderboardSnapshot extends Model
+{
+    use HasConfigurableIds, ResolvesConfiguredTable;
+
+    protected $guarded = [];
+
+    protected $casts = [
+        'rank' => 'integer',
+        'score' => 'float',
+        'run_at' => 'datetime',
+    ];
+
+    /**
+     * @return BelongsTo<Model, $this>
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(config(key: 'level-up.user.model'));
+    }
+
+    protected function configuredTableKey(): string
+    {
+        return 'leaderboard_snapshots';
+    }
+}

--- a/src/Providers/EventServiceProvider.php
+++ b/src/Providers/EventServiceProvider.php
@@ -6,9 +6,11 @@ namespace LevelUp\Experience\Providers;
 
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
 use LevelUp\Experience\Events\AchievementAwarded;
+use LevelUp\Experience\Events\LeaderboardRankChanged;
 use LevelUp\Experience\Events\PointsDecreased;
 use LevelUp\Experience\Events\PointsIncreased;
 use LevelUp\Experience\Events\StreakIncreased;
+use LevelUp\Experience\Events\UserEnteredTrackedDepth;
 use LevelUp\Experience\Events\UserLevelledUp;
 use LevelUp\Experience\Events\UserTierUpdated;
 use LevelUp\Experience\Listeners\ChallengeProgressListener;
@@ -39,6 +41,12 @@ class EventServiceProvider extends ServiceProvider
             ChallengeProgressListener::class,
         ],
         StreakIncreased::class => [
+            ChallengeProgressListener::class,
+        ],
+        LeaderboardRankChanged::class => [
+            ChallengeProgressListener::class,
+        ],
+        UserEnteredTrackedDepth::class => [
             ChallengeProgressListener::class,
         ],
     ];

--- a/src/Services/ChallengeService.php
+++ b/src/Services/ChallengeService.php
@@ -147,6 +147,14 @@ class ChallengeService
 
         $activityModel = config(key: 'level-up.models.activity');
 
+        $boardNames = $challenges
+            ->flatMap(fn (Challenge $challenge): array => $challenge->conditions)
+            ->where('type', 'leaderboard_rank')
+            ->pluck('board')
+            ->filter()
+            ->unique()
+            ->all();
+
         return [
             'achievement_ids' => method_exists($user, 'allAchievements')
                 ? $user->allAchievements()->pluck(config('level-up.tables.achievements').'.id')->all()
@@ -154,7 +162,42 @@ class ChallengeService
             'activities' => $activityNames !== []
                 ? $activityModel::whereIn('name', $activityNames)->get()->keyBy('name')
                 : collect(),
+            'board_ranks' => $this->latestSnapshotRanks(user: $user, boardNames: $boardNames),
         ];
+    }
+
+    /**
+     * @param  array<string>  $boardNames
+     * @return array<string, int>
+     */
+    protected function latestSnapshotRanks(Model $user, array $boardNames): array
+    {
+        $snapshotModel = config(key: 'level-up.models.leaderboard_snapshot');
+        $userForeignKey = config()->string(key: 'level-up.user.foreign_key');
+
+        $ranks = [];
+
+        foreach ($boardNames as $board) {
+            $latestRunAt = $snapshotModel::query()
+                ->where(column: 'board', operator: '=', value: $board)
+                ->max(column: 'run_at');
+
+            if ($latestRunAt === null) {
+                continue;
+            }
+
+            $rank = $snapshotModel::query()
+                ->where(column: 'board', operator: '=', value: $board)
+                ->where(column: 'run_at', operator: '=', value: $latestRunAt)
+                ->where(column: $userForeignKey, operator: '=', value: $user->getKey())
+                ->value(column: 'rank');
+
+            if ($rank !== null) {
+                $ranks[$board] = (int) $rank;
+            }
+        }
+
+        return $ranks;
     }
 
     protected function evaluateChallenge(Model $user, Challenge $challenge, array $preloaded = []): void
@@ -208,6 +251,7 @@ class ChallengeService
             'achievement_earned' => $this->checkAchievementEarned(condition: $condition, preloaded: $preloaded),
             'streak_count' => $this->checkStreakCount(user: $user, condition: $condition, preloaded: $preloaded),
             'tier_reached' => $this->checkTierReached(user: $user, condition: $condition),
+            'leaderboard_rank' => $this->checkLeaderboardRank(condition: $condition, preloaded: $preloaded),
             'custom' => $this->checkCustomCondition(user: $user, condition: $condition),
             default => $this->reportAndFail("Unknown challenge condition type '{$condition['type']}'"),
         };
@@ -261,6 +305,13 @@ class ChallengeService
         }
 
         return $user->isAtOrAboveTier($condition['tier'] ?? '');
+    }
+
+    protected function checkLeaderboardRank(array $condition, array $preloaded = []): bool
+    {
+        $rank = ($preloaded['board_ranks'] ?? [])[$condition['board'] ?? ''] ?? null;
+
+        return $rank !== null && $rank <= ($condition['rank'] ?? 0);
     }
 
     protected function checkCustomCondition(Model $user, array $condition): bool

--- a/tests/Config/ResolveTablesTest.php
+++ b/tests/Config/ResolveTablesTest.php
@@ -25,6 +25,7 @@ it('returns defaults when no prefix or overrides are set', function (): void {
         'multiplier_tier' => 'multiplier_tier',
         'challenges' => 'challenges',
         'challenge_user' => 'challenge_user',
+        'leaderboard_snapshots' => 'leaderboard_snapshots',
     ]);
 });
 

--- a/tests/Listeners/ChallengeProgressListenerTest.php
+++ b/tests/Listeners/ChallengeProgressListenerTest.php
@@ -5,8 +5,11 @@ declare(strict_types=1);
 use Illuminate\Support\Facades\Event;
 use LevelUp\Experience\Events\AchievementAwarded;
 use LevelUp\Experience\Events\ChallengeCompleted;
+use LevelUp\Experience\Events\LeaderboardRankChanged;
 use LevelUp\Experience\Events\PointsIncreased;
 use LevelUp\Experience\Events\StreakIncreased;
+use LevelUp\Experience\Events\UserEnteredTrackedDepth;
+use LevelUp\Experience\Events\UserLeftTrackedDepth;
 use LevelUp\Experience\Events\UserLevelledUp;
 use LevelUp\Experience\Events\UserTierUpdated;
 use LevelUp\Experience\Listeners\ChallengeProgressListener;
@@ -43,6 +46,31 @@ test(description: 'ChallengeProgressListener is registered on UserLevelledUp', c
 test(description: 'ChallengeProgressListener is registered on UserTierUpdated', closure: function (): void {
     Event::fake();
     Event::assertListening(expectedEvent: UserTierUpdated::class, expectedListener: ChallengeProgressListener::class);
+});
+
+test(description: 'ChallengeProgressListener is registered on LeaderboardRankChanged', closure: function (): void {
+    Event::fake();
+    Event::assertListening(expectedEvent: LeaderboardRankChanged::class, expectedListener: ChallengeProgressListener::class);
+});
+
+test(description: 'ChallengeProgressListener is registered on UserEnteredTrackedDepth', closure: function (): void {
+    Event::fake();
+    Event::assertListening(expectedEvent: UserEnteredTrackedDepth::class, expectedListener: ChallengeProgressListener::class);
+});
+
+test(description: 'ChallengeProgressListener is NOT registered on UserLeftTrackedDepth', closure: function (): void {
+    Event::fake();
+
+    $listening = false;
+
+    try {
+        Event::assertListening(expectedEvent: UserLeftTrackedDepth::class, expectedListener: ChallengeProgressListener::class);
+        $listening = true;
+    } catch (PHPUnit\Framework\AssertionFailedError) {
+        $listening = false;
+    }
+
+    expect($listening)->toBeFalse();
 });
 
 test(description: 'ChallengeProgressListener is NOT registered on ChallengeCompleted', closure: function (): void {

--- a/tests/Migrations/TablePrefixIntegrationTest.php
+++ b/tests/Migrations/TablePrefixIntegrationTest.php
@@ -31,6 +31,7 @@ class TablePrefixIntegrationTest extends TestCase
         $this->assertTrue(Schema::hasTable('pfx_multiplier_tier'));
         $this->assertTrue(Schema::hasTable('pfx_challenges'));
         $this->assertTrue(Schema::hasTable('pfx_challenge_user'));
+        $this->assertTrue(Schema::hasTable('pfx_leaderboard_snapshots'));
     }
 
     public function test_explicit_override_escapes_the_prefix(): void

--- a/tests/Services/ChallengeLeaderboardRankTest.php
+++ b/tests/Services/ChallengeLeaderboardRankTest.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Facades\Date;
 use LevelUp\Experience\Events\LeaderboardRankChanged;
 use LevelUp\Experience\Models\Challenge;
 use LevelUp\Experience\Models\Experience;
+use LevelUp\Experience\Models\Level;
 use LevelUp\Experience\Tests\Fixtures\User;
 
 uses()->group('challenges', 'leaderboard');
@@ -120,8 +121,8 @@ test(description: 'rank events from another board do not satisfy a condition key
     $this->travelTo(Date::parse(time: '2026-06-01 06:00:00'));
 
     $rival = User::newFactory()->create();
-    Experience::query()->create(attributes: ['user_id' => $rival->id, 'level_id' => 2, 'experience_points' => 150]);
-    Experience::query()->create(attributes: ['user_id' => $this->user->id, 'level_id' => 1, 'experience_points' => 100]);
+    Experience::query()->create(attributes: ['user_id' => $rival->id, 'level_id' => Level::query()->where(column: 'level', operator: '=', value: 2)->value(column: 'id'), 'experience_points' => 150]);
+    Experience::query()->create(attributes: ['user_id' => $this->user->id, 'level_id' => Level::query()->where(column: 'level', operator: '=', value: 1)->value(column: 'id'), 'experience_points' => 100]);
     $this->user->enrollInChallenge(challenge: $challenge);
 
     $this->artisan(command: 'level-up:snapshot-boards')->assertSuccessful();

--- a/tests/Services/ChallengeLeaderboardRankTest.php
+++ b/tests/Services/ChallengeLeaderboardRankTest.php
@@ -1,0 +1,310 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Date;
+use LevelUp\Experience\Events\LeaderboardRankChanged;
+use LevelUp\Experience\Models\Challenge;
+use LevelUp\Experience\Models\Experience;
+use LevelUp\Experience\Tests\Fixtures\User;
+
+uses()->group('challenges', 'leaderboard');
+
+beforeEach(closure: function (): void {
+    config()->set(key: 'level-up.multiplier.enabled', value: false);
+    config()->set(key: 'level-up.challenges.enabled', value: true);
+    config()->set(key: 'level-up.user.model', value: User::class);
+});
+
+test(description: 'rank change to within the target completes the challenge on the snapshot run', closure: function (): void {
+    config()->set(key: 'level-up.leaderboard.boards', value: [
+        'xp-board' => ['metric' => 'xp'],
+    ]);
+
+    $challenge = Challenge::factory()->create([
+        'conditions' => [
+            ['type' => 'leaderboard_rank', 'board' => 'xp-board', 'rank' => 1],
+        ],
+        'rewards' => [],
+    ]);
+
+    $this->travelTo(Date::parse(time: '2026-06-01 06:00:00'));
+
+    $rival = tap(User::newFactory()->create())->addPoints(100);
+    $this->user->addPoints(amount: 50);
+    $this->user->enrollInChallenge(challenge: $challenge);
+
+    $this->artisan(command: 'level-up:snapshot-boards')->assertSuccessful();
+
+    $this->travelTo(Date::parse(time: '2026-06-02 06:00:00'));
+    $this->user->addPoints(amount: 100);
+
+    $this->artisan(command: 'level-up:snapshot-boards')->assertSuccessful();
+
+    expect($this->user->fresh()->completedChallenges)->toHaveCount(count: 1)
+        ->and($rival->fresh()->challenges)->toHaveCount(count: 0);
+});
+
+test(description: 'rank change that stays worse than the target does not complete the challenge', closure: function (): void {
+    config()->set(key: 'level-up.leaderboard.boards', value: [
+        'xp-board' => ['metric' => 'xp'],
+    ]);
+
+    $challenge = Challenge::factory()->create([
+        'conditions' => [
+            ['type' => 'leaderboard_rank', 'board' => 'xp-board', 'rank' => 1],
+        ],
+        'rewards' => [],
+    ]);
+
+    $this->travelTo(Date::parse(time: '2026-06-01 06:00:00'));
+
+    tap(User::newFactory()->create())->addPoints(300);
+    tap(User::newFactory()->create())->addPoints(200);
+    $this->user->addPoints(amount: 100);
+    $this->user->enrollInChallenge(challenge: $challenge);
+
+    $this->artisan(command: 'level-up:snapshot-boards')->assertSuccessful();
+
+    $this->travelTo(Date::parse(time: '2026-06-02 06:00:00'));
+    $this->user->addPoints(amount: 150);
+
+    $this->artisan(command: 'level-up:snapshot-boards')->assertSuccessful();
+
+    expect($this->user->fresh()->activeChallenges)->toHaveCount(count: 1)
+        ->and($this->user->fresh()->completedChallenges)->toHaveCount(count: 0);
+});
+
+test(description: 'entering the tracked depth at or above the target completes the challenge', closure: function (): void {
+    config()->set(key: 'level-up.leaderboard.boards', value: [
+        'xp-board' => ['metric' => 'xp', 'track_top' => 2],
+    ]);
+
+    $challenge = Challenge::factory()->create([
+        'conditions' => [
+            ['type' => 'leaderboard_rank', 'board' => 'xp-board', 'rank' => 2],
+        ],
+        'rewards' => [],
+    ]);
+
+    $this->travelTo(Date::parse(time: '2026-06-01 06:00:00'));
+
+    tap(User::newFactory()->create())->addPoints(300);
+    tap(User::newFactory()->create())->addPoints(200);
+    $this->user->addPoints(amount: 100);
+    $this->user->enrollInChallenge(challenge: $challenge);
+
+    $this->artisan(command: 'level-up:snapshot-boards')->assertSuccessful();
+
+    $this->travelTo(Date::parse(time: '2026-06-02 06:00:00'));
+    $this->user->addPoints(amount: 150);
+
+    $this->artisan(command: 'level-up:snapshot-boards')->assertSuccessful();
+
+    expect($this->user->fresh()->completedChallenges)->toHaveCount(count: 1);
+});
+
+test(description: 'rank events from another board do not satisfy a condition keyed to a different board', closure: function (): void {
+    config()->set(key: 'level-up.leaderboard.boards', value: [
+        'xp-board' => ['metric' => 'xp'],
+        'level-board' => ['metric' => 'level'],
+    ]);
+
+    $challenge = Challenge::factory()->create([
+        'conditions' => [
+            ['type' => 'leaderboard_rank', 'board' => 'level-board', 'rank' => 1],
+        ],
+        'rewards' => [],
+    ]);
+
+    $this->travelTo(Date::parse(time: '2026-06-01 06:00:00'));
+
+    $rival = User::newFactory()->create();
+    Experience::query()->create(attributes: ['user_id' => $rival->id, 'level_id' => 2, 'experience_points' => 150]);
+    Experience::query()->create(attributes: ['user_id' => $this->user->id, 'level_id' => 1, 'experience_points' => 100]);
+    $this->user->enrollInChallenge(challenge: $challenge);
+
+    $this->artisan(command: 'level-up:snapshot-boards')->assertSuccessful();
+
+    $this->travelTo(Date::parse(time: '2026-06-02 06:00:00'));
+    Experience::query()->where(column: 'user_id', operator: '=', value: $this->user->id)->update(['experience_points' => 300]);
+
+    $this->artisan(command: 'level-up:snapshot-boards')->assertSuccessful();
+
+    expect($this->user->fresh()->activeChallenges)->toHaveCount(count: 1)
+        ->and($this->user->fresh()->completedChallenges)->toHaveCount(count: 0);
+});
+
+test(description: 'condition stays unmet when the named board has never been snapshotted', closure: function (): void {
+    config()->set(key: 'level-up.leaderboard.boards', value: [
+        'xp-board' => ['metric' => 'xp'],
+    ]);
+
+    $challenge = Challenge::factory()->create([
+        'conditions' => [
+            ['type' => 'leaderboard_rank', 'board' => 'xp-board', 'rank' => 1],
+        ],
+        'rewards' => [],
+    ]);
+
+    $this->user->enrollInChallenge(challenge: $challenge);
+
+    event(new LeaderboardRankChanged(user: $this->user, board: 'xp-board', from: 2, to: 1));
+
+    expect($this->user->fresh()->activeChallenges)->toHaveCount(count: 1)
+        ->and($this->user->fresh()->completedChallenges)->toHaveCount(count: 0);
+});
+
+test(description: 'a user missing from the latest snapshot run does not meet the condition in a mixed challenge', closure: function (): void {
+    config()->set(key: 'level-up.leaderboard.boards', value: [
+        'xp-board' => ['metric' => 'xp', 'track_top' => 1],
+    ]);
+
+    $challenge = Challenge::factory()->create([
+        'conditions' => [
+            ['type' => 'points_earned', 'amount' => 50],
+            ['type' => 'leaderboard_rank', 'board' => 'xp-board', 'rank' => 1],
+        ],
+        'rewards' => [],
+    ]);
+
+    tap(User::newFactory()->create())->addPoints(500);
+
+    $this->artisan(command: 'level-up:snapshot-boards')->assertSuccessful();
+
+    $this->user->enrollInChallenge(challenge: $challenge);
+    $this->user->addPoints(amount: 60);
+
+    expect($this->user->fresh()->getChallengeProgress(challenge: $challenge))->toBe([
+        ['type' => 'points_earned', 'completed' => true, 'baseline' => 0],
+        ['type' => 'leaderboard_rank', 'completed' => false],
+    ])->and($this->user->fresh()->completedChallenges)->toHaveCount(count: 0);
+});
+
+test(description: 'rank events auto-enroll users into auto_enroll leaderboard challenges', closure: function (): void {
+    config()->set(key: 'level-up.leaderboard.boards', value: [
+        'xp-board' => ['metric' => 'xp'],
+    ]);
+
+    $challenge = Challenge::factory()->autoEnroll()->create([
+        'conditions' => [
+            ['type' => 'leaderboard_rank', 'board' => 'xp-board', 'rank' => 1],
+        ],
+        'rewards' => [],
+    ]);
+
+    $this->travelTo(Date::parse(time: '2026-06-01 06:00:00'));
+
+    tap(User::newFactory()->create())->addPoints(100);
+    $this->user->addPoints(amount: 50);
+
+    $this->artisan(command: 'level-up:snapshot-boards')->assertSuccessful();
+
+    $this->travelTo(Date::parse(time: '2026-06-02 06:00:00'));
+    $this->user->addPoints(amount: 100);
+
+    $this->artisan(command: 'level-up:snapshot-boards')->assertSuccessful();
+
+    expect($this->user->fresh()->completedChallenges)->toHaveCount(count: 1)
+        ->and($this->user->fresh()->completedChallenges->first()->is($challenge))->toBeTrue();
+});
+
+test(description: 'rank events do not evaluate challenges without leaderboard_rank conditions', closure: function (): void {
+    config()->set(key: 'level-up.leaderboard.boards', value: [
+        'xp-board' => ['metric' => 'xp'],
+    ]);
+
+    $challenge = Challenge::factory()->create([
+        'conditions' => [
+            ['type' => 'points_earned', 'amount' => 10],
+        ],
+        'rewards' => [],
+    ]);
+
+    $this->user->enrollInChallenge(challenge: $challenge);
+
+    Experience::query()->create(attributes: ['user_id' => $this->user->id, 'level_id' => 1, 'experience_points' => 100]);
+
+    event(new LeaderboardRankChanged(user: $this->user, board: 'xp-board', from: 2, to: 1));
+
+    expect($this->user->fresh()->activeChallenges)->toHaveCount(count: 1)
+        ->and($this->user->fresh()->completedChallenges)->toHaveCount(count: 0);
+});
+
+test(description: 'validation rejects a board that is not declared in config', closure: function (): void {
+    config()->set(key: 'level-up.leaderboard.boards', value: [
+        'xp-board' => ['metric' => 'xp'],
+    ]);
+
+    expect(fn (): Challenge => Challenge::factory()->create([
+        'conditions' => [
+            ['type' => 'leaderboard_rank', 'board' => 'ghost-board', 'rank' => 1],
+        ],
+    ]))->toThrow(exception: InvalidArgumentException::class, exceptionMessage: "board 'ghost-board' is not declared in level-up.leaderboard.boards");
+});
+
+test(description: 'validation rejects a non-string board name', closure: function (): void {
+    expect(fn (): Challenge => Challenge::factory()->create([
+        'conditions' => [
+            ['type' => 'leaderboard_rank', 'board' => 123, 'rank' => 1],
+        ],
+    ]))->toThrow(exception: InvalidArgumentException::class, exceptionMessage: "'board' must be a board name string");
+});
+
+test(description: 'validation rejects a rank that is not a positive integer', closure: function (): void {
+    config()->set(key: 'level-up.leaderboard.boards', value: [
+        'xp-board' => ['metric' => 'xp'],
+    ]);
+
+    expect(fn (): Challenge => Challenge::factory()->create([
+        'conditions' => [
+            ['type' => 'leaderboard_rank', 'board' => 'xp-board', 'rank' => 0],
+        ],
+    ]))->toThrow(exception: InvalidArgumentException::class, exceptionMessage: "'rank' must be a positive integer");
+});
+
+test(description: 'validation rejects a rank deeper than the board default tracked depth of 100', closure: function (): void {
+    config()->set(key: 'level-up.leaderboard.boards', value: [
+        'xp-board' => ['metric' => 'xp'],
+    ]);
+
+    expect(fn (): Challenge => Challenge::factory()->create([
+        'conditions' => [
+            ['type' => 'leaderboard_rank', 'board' => 'xp-board', 'rank' => 150],
+        ],
+    ]))->toThrow(exception: InvalidArgumentException::class, exceptionMessage: "rank 150 is deeper than board 'xp-board' tracked depth (100)");
+});
+
+test(description: 'validation rejects a rank deeper than a per-board track_top override', closure: function (): void {
+    config()->set(key: 'level-up.leaderboard.boards', value: [
+        'xp-board' => ['metric' => 'xp', 'track_top' => 10],
+    ]);
+
+    expect(fn (): Challenge => Challenge::factory()->create([
+        'conditions' => [
+            ['type' => 'leaderboard_rank', 'board' => 'xp-board', 'rank' => 11],
+        ],
+    ]))->toThrow(exception: InvalidArgumentException::class, exceptionMessage: "rank 11 is deeper than board 'xp-board' tracked depth (10)");
+});
+
+test(description: 'validation accepts a rank within a raised track_top', closure: function (): void {
+    config()->set(key: 'level-up.leaderboard.boards', value: [
+        'xp-board' => ['metric' => 'xp', 'track_top' => 150],
+    ]);
+
+    $challenge = Challenge::factory()->create([
+        'conditions' => [
+            ['type' => 'leaderboard_rank', 'board' => 'xp-board', 'rank' => 120],
+        ],
+    ]);
+
+    expect($challenge->exists)->toBeTrue();
+});
+
+test(description: 'validation rejects a leaderboard_rank condition missing its required keys', closure: function (): void {
+    expect(fn (): Challenge => Challenge::factory()->create([
+        'conditions' => [
+            ['type' => 'leaderboard_rank'],
+        ],
+    ]))->toThrow(exception: InvalidArgumentException::class, exceptionMessage: "missing required key 'board'");
+});

--- a/tests/Services/LeaderboardSnapshotsTest.php
+++ b/tests/Services/LeaderboardSnapshotsTest.php
@@ -1,0 +1,346 @@
+<?php
+
+declare(strict_types=1);
+
+uses()->group('leaderboard');
+
+use Illuminate\Support\Facades\Date;
+use Illuminate\Support\Facades\Event;
+use LevelUp\Experience\Events\LeaderboardRankChanged;
+use LevelUp\Experience\Events\UserEnteredTrackedDepth;
+use LevelUp\Experience\Events\UserLeftTrackedDepth;
+use LevelUp\Experience\Models\Experience;
+use LevelUp\Experience\Models\LeaderboardSnapshot;
+use LevelUp\Experience\Tests\Fixtures\User;
+
+beforeEach(function (): void {
+    config(['level-up.user.model' => User::class]);
+    config(['level-up.multiplier.enabled' => false]);
+});
+
+it(description: 'snapshots the top entries of a declared Board', closure: function (): void {
+    config(['level-up.leaderboard.boards' => [
+        'xp-board' => ['metric' => 'xp'],
+    ]]);
+
+    $this->travelTo(Date::parse(time: '2026-06-01 06:00:00'));
+
+    $leader = tap(User::newFactory()->create())->addPoints(300);
+    $runnerUp = tap(User::newFactory()->create())->addPoints(100);
+
+    $this->artisan(command: 'level-up:snapshot-boards')->assertSuccessful();
+
+    $snapshots = LeaderboardSnapshot::query()->orderBy(column: 'rank')->get();
+
+    expect($snapshots)->toHaveCount(count: 2)
+        ->and($snapshots->first()->board)->toBe(expected: 'xp-board')
+        ->and($snapshots->first()->user_id)->toEqual($leader->id)
+        ->and($snapshots->first()->rank)->toBe(expected: 1)
+        ->and($snapshots->first()->score)->toBe(expected: 300.0)
+        ->and($snapshots->first()->run_at)->toBeCarbon(expected: '2026-06-01 06:00:00')
+        ->and($snapshots->last()->user_id)->toEqual($runnerUp->id)
+        ->and($snapshots->last()->rank)->toBe(expected: 2);
+});
+
+it(description: 'stores no snapshot rows below the default tracked depth of 100', closure: function (): void {
+    config(['level-up.leaderboard.boards' => [
+        'xp-board' => ['metric' => 'xp'],
+    ]]);
+
+    $users = User::newFactory()->count(count: 101)->create();
+
+    $users->each(function (User $user, int $index): void {
+        Experience::query()->create(attributes: [
+            'user_id' => $user->id,
+            'level_id' => 1,
+            'experience_points' => 1000 - $index,
+        ]);
+    });
+
+    $this->artisan(command: 'level-up:snapshot-boards')->assertSuccessful();
+
+    $hindmost = $users->last();
+
+    expect(LeaderboardSnapshot::query()->count())->toBe(expected: 100)
+        ->and(LeaderboardSnapshot::query()->where(column: 'user_id', operator: '=', value: $hindmost->id)->exists())->toBeFalse();
+});
+
+it(description: 'bounds the snapshot by a per-Board track_top override', closure: function (): void {
+    config(['level-up.leaderboard.boards' => [
+        'xp-board' => ['metric' => 'xp', 'track_top' => 2],
+    ]]);
+
+    tap(User::newFactory()->create())->addPoints(300);
+    tap(User::newFactory()->create())->addPoints(200);
+    $belowDepth = tap(User::newFactory()->create())->addPoints(100);
+
+    $this->artisan(command: 'level-up:snapshot-boards')->assertSuccessful();
+
+    expect(LeaderboardSnapshot::query()->count())->toBe(expected: 2)
+        ->and(LeaderboardSnapshot::query()->where(column: 'user_id', operator: '=', value: $belowDepth->id)->exists())->toBeFalse();
+});
+
+it(description: 'dispatches rank-changed events with from and to ranks when a second run diffs against the first', closure: function (): void {
+    config(['level-up.leaderboard.boards' => [
+        'xp-board' => ['metric' => 'xp'],
+    ]]);
+
+    $this->travelTo(Date::parse(time: '2026-06-01 06:00:00'));
+
+    $overtaken = tap(User::newFactory()->create())->addPoints(100);
+    $climber = tap(User::newFactory()->create())->addPoints(50);
+
+    $this->artisan(command: 'level-up:snapshot-boards')->assertSuccessful();
+
+    $this->travelTo(Date::parse(time: '2026-06-02 06:00:00'));
+    $climber->addPoints(100);
+
+    Event::fake(eventsToFake: [LeaderboardRankChanged::class]);
+
+    $this->artisan(command: 'level-up:snapshot-boards')->assertSuccessful();
+
+    Event::assertDispatched(
+        event: LeaderboardRankChanged::class,
+        callback: fn (LeaderboardRankChanged $event): bool => $event->user->is(model: $climber)
+            && $event->board === 'xp-board'
+            && $event->from === 2
+            && $event->to === 1,
+    );
+    Event::assertDispatched(
+        event: LeaderboardRankChanged::class,
+        callback: fn (LeaderboardRankChanged $event): bool => $event->user->is(model: $overtaken)
+            && $event->board === 'xp-board'
+            && $event->from === 1
+            && $event->to === 2,
+    );
+    Event::assertDispatchedTimes(event: LeaderboardRankChanged::class, times: 2);
+});
+
+it(description: 'dispatches an entered event when a user breaks into the tracked depth', closure: function (): void {
+    config(['level-up.leaderboard.boards' => [
+        'xp-board' => ['metric' => 'xp', 'track_top' => 2],
+    ]]);
+
+    $this->travelTo(Date::parse(time: '2026-06-01 06:00:00'));
+
+    tap(User::newFactory()->create())->addPoints(300);
+    $displaced = tap(User::newFactory()->create())->addPoints(200);
+    $climber = tap(User::newFactory()->create())->addPoints(100);
+
+    $this->artisan(command: 'level-up:snapshot-boards')->assertSuccessful();
+
+    $this->travelTo(Date::parse(time: '2026-06-02 06:00:00'));
+    $climber->addPoints(150);
+
+    Event::fake(eventsToFake: [UserEnteredTrackedDepth::class, UserLeftTrackedDepth::class]);
+
+    $this->artisan(command: 'level-up:snapshot-boards')->assertSuccessful();
+
+    Event::assertDispatched(
+        event: UserEnteredTrackedDepth::class,
+        callback: fn (UserEnteredTrackedDepth $event): bool => $event->user->is(model: $climber)
+            && $event->board === 'xp-board'
+            && $event->rank === 2,
+    );
+    Event::assertDispatchedTimes(event: UserEnteredTrackedDepth::class, times: 1);
+    Event::assertDispatched(
+        event: UserLeftTrackedDepth::class,
+        callback: fn (UserLeftTrackedDepth $event): bool => $event->user->is(model: $displaced)
+            && $event->board === 'xp-board'
+            && $event->previousRank === 2,
+    );
+    Event::assertDispatchedTimes(event: UserLeftTrackedDepth::class, times: 1);
+});
+
+it(description: 'stays silent for rank shuffles below the tracked depth', closure: function (): void {
+    config(['level-up.leaderboard.boards' => [
+        'xp-board' => ['metric' => 'xp', 'track_top' => 2],
+    ]]);
+
+    $this->travelTo(Date::parse(time: '2026-06-01 06:00:00'));
+
+    tap(User::newFactory()->create())->addPoints(300);
+    tap(User::newFactory()->create())->addPoints(200);
+    $midTable = tap(User::newFactory()->create())->addPoints(100);
+    tap(User::newFactory()->create())->addPoints(50);
+
+    $this->artisan(command: 'level-up:snapshot-boards')->assertSuccessful();
+
+    $this->travelTo(Date::parse(time: '2026-06-02 06:00:00'));
+    $midTable->addPoints(20);
+
+    Event::fake(eventsToFake: [LeaderboardRankChanged::class, UserEnteredTrackedDepth::class, UserLeftTrackedDepth::class]);
+
+    $this->artisan(command: 'level-up:snapshot-boards')->assertSuccessful();
+
+    Event::assertNotDispatched(event: LeaderboardRankChanged::class);
+    Event::assertNotDispatched(event: UserEnteredTrackedDepth::class);
+    Event::assertNotDispatched(event: UserLeftTrackedDepth::class);
+});
+
+it(description: 'dispatches nothing when a run finds no rank movement', closure: function (): void {
+    config(['level-up.leaderboard.boards' => [
+        'xp-board' => ['metric' => 'xp'],
+    ]]);
+
+    $this->travelTo(Date::parse(time: '2026-06-01 06:00:00'));
+
+    tap(User::newFactory()->create())->addPoints(300);
+    tap(User::newFactory()->create())->addPoints(100);
+
+    $this->artisan(command: 'level-up:snapshot-boards')->assertSuccessful();
+
+    $this->travelTo(Date::parse(time: '2026-06-02 06:00:00'));
+
+    Event::fake(eventsToFake: [LeaderboardRankChanged::class, UserEnteredTrackedDepth::class, UserLeftTrackedDepth::class]);
+
+    $this->artisan(command: 'level-up:snapshot-boards')->assertSuccessful();
+
+    Event::assertNotDispatched(event: LeaderboardRankChanged::class);
+    Event::assertNotDispatched(event: UserEnteredTrackedDepth::class);
+    Event::assertNotDispatched(event: UserLeftTrackedDepth::class);
+});
+
+it(description: 'prunes snapshot runs older than the configured retention', closure: function (): void {
+    config(['level-up.leaderboard.boards' => [
+        'xp-board' => ['metric' => 'xp'],
+    ]]);
+
+    tap(User::newFactory()->create())->addPoints(300);
+
+    $this->travelTo(Date::parse(time: '2026-06-01 06:00:00'));
+    $this->artisan(command: 'level-up:snapshot-boards')->assertSuccessful();
+
+    $this->travelTo(Date::parse(time: '2026-06-16 06:00:00'));
+    $this->artisan(command: 'level-up:snapshot-boards')->assertSuccessful();
+
+    $this->travelTo(Date::parse(time: '2026-07-02 06:00:00'));
+    $this->artisan(command: 'level-up:snapshot-boards')->assertSuccessful();
+
+    $remainingRuns = LeaderboardSnapshot::query()->pluck(column: 'run_at')->map(fn ($runAt): string => $runAt->format('Y-m-d H:i:s'));
+
+    expect($remainingRuns->all())->toBe(['2026-06-16 06:00:00', '2026-07-02 06:00:00']);
+});
+
+it(description: 'respects a custom retention_days config when pruning', closure: function (): void {
+    config(['level-up.leaderboard.boards' => [
+        'xp-board' => ['metric' => 'xp'],
+    ]]);
+    config(['level-up.leaderboard.snapshots.retention_days' => 7]);
+
+    tap(User::newFactory()->create())->addPoints(300);
+
+    $this->travelTo(Date::parse(time: '2026-06-01 06:00:00'));
+    $this->artisan(command: 'level-up:snapshot-boards')->assertSuccessful();
+
+    $this->travelTo(Date::parse(time: '2026-06-09 06:00:00'));
+    $this->artisan(command: 'level-up:snapshot-boards')->assertSuccessful();
+
+    $remainingRuns = LeaderboardSnapshot::query()->pluck(column: 'run_at')->map(fn ($runAt): string => $runAt->format('Y-m-d H:i:s'));
+
+    expect($remainingRuns->all())->toBe(['2026-06-09 06:00:00']);
+});
+
+it(description: 'dispatches nothing on the first run of a Board because there is no previous run to diff', closure: function (): void {
+    config(['level-up.leaderboard.boards' => [
+        'xp-board' => ['metric' => 'xp'],
+    ]]);
+
+    tap(User::newFactory()->create())->addPoints(300);
+    tap(User::newFactory()->create())->addPoints(100);
+
+    Event::fake(eventsToFake: [LeaderboardRankChanged::class, UserEnteredTrackedDepth::class, UserLeftTrackedDepth::class]);
+
+    $this->artisan(command: 'level-up:snapshot-boards')->assertSuccessful();
+
+    expect(LeaderboardSnapshot::query()->count())->toBe(expected: 2);
+
+    Event::assertNotDispatched(event: LeaderboardRankChanged::class);
+    Event::assertNotDispatched(event: UserEnteredTrackedDepth::class);
+    Event::assertNotDispatched(event: UserLeftTrackedDepth::class);
+});
+
+it(description: 'diffs each declared Board in isolation', closure: function (): void {
+    config(['level-up.leaderboard.boards' => [
+        'xp-board' => ['metric' => 'xp'],
+        'level-board' => ['metric' => 'level'],
+    ]]);
+
+    $this->travelTo(Date::parse(time: '2026-06-01 06:00:00'));
+
+    $overtaken = tap(User::newFactory()->create())->addPoints(200);
+    $climber = tap(User::newFactory()->create())->addPoints(180);
+
+    $this->artisan(command: 'level-up:snapshot-boards')->assertSuccessful();
+
+    $this->travelTo(Date::parse(time: '2026-06-02 06:00:00'));
+    $climber->addPoints(30);
+
+    Event::fake(eventsToFake: [LeaderboardRankChanged::class, UserEnteredTrackedDepth::class, UserLeftTrackedDepth::class]);
+
+    $this->artisan(command: 'level-up:snapshot-boards')->assertSuccessful();
+
+    expect(LeaderboardSnapshot::query()->where(column: 'board', operator: '=', value: 'xp-board')->count())->toBe(expected: 4)
+        ->and(LeaderboardSnapshot::query()->where(column: 'board', operator: '=', value: 'level-board')->count())->toBe(expected: 4);
+
+    Event::assertDispatched(
+        event: LeaderboardRankChanged::class,
+        callback: fn (LeaderboardRankChanged $event): bool => $event->board === 'xp-board',
+    );
+    Event::assertNotDispatched(
+        event: LeaderboardRankChanged::class,
+        callback: fn (LeaderboardRankChanged $event): bool => $event->board === 'level-board',
+    );
+    Event::assertNotDispatched(event: UserEnteredTrackedDepth::class);
+    Event::assertNotDispatched(event: UserLeftTrackedDepth::class);
+});
+
+it(description: 'replaces the rows of a same-instant run instead of duplicating them', closure: function (): void {
+    config(['level-up.leaderboard.boards' => [
+        'xp-board' => ['metric' => 'xp'],
+    ]]);
+
+    $this->travelTo(Date::parse(time: '2026-06-01 06:00:00'));
+
+    tap(User::newFactory()->create())->addPoints(300);
+    tap(User::newFactory()->create())->addPoints(100);
+
+    $this->artisan(command: 'level-up:snapshot-boards')->assertSuccessful();
+    $this->artisan(command: 'level-up:snapshot-boards')->assertSuccessful();
+
+    $snapshots = LeaderboardSnapshot::query()->orderBy(column: 'rank')->get();
+
+    expect($snapshots)->toHaveCount(count: 2)
+        ->and($snapshots->map(fn (LeaderboardSnapshot $snapshot): int => $snapshot->rank)->all())->toBe([1, 2]);
+});
+
+it(description: 'reports only real movement when a tie breaks', closure: function (): void {
+    config(['level-up.leaderboard.boards' => [
+        'xp-board' => ['metric' => 'xp'],
+    ]]);
+
+    $this->travelTo(Date::parse(time: '2026-06-01 06:00:00'));
+
+    $slipped = tap(User::newFactory()->create())->addPoints(100);
+    $tieBreaker = tap(User::newFactory()->create())->addPoints(100);
+    tap(User::newFactory()->create())->addPoints(90);
+
+    $this->artisan(command: 'level-up:snapshot-boards')->assertSuccessful();
+
+    $this->travelTo(Date::parse(time: '2026-06-02 06:00:00'));
+    $tieBreaker->addPoints(50);
+
+    Event::fake(eventsToFake: [LeaderboardRankChanged::class, UserEnteredTrackedDepth::class, UserLeftTrackedDepth::class]);
+
+    $this->artisan(command: 'level-up:snapshot-boards')->assertSuccessful();
+
+    Event::assertDispatched(
+        event: LeaderboardRankChanged::class,
+        callback: fn (LeaderboardRankChanged $event): bool => $event->user->is(model: $slipped)
+            && $event->from === 1
+            && $event->to === 2,
+    );
+    Event::assertDispatchedTimes(event: LeaderboardRankChanged::class, times: 1);
+    Event::assertNotDispatched(event: UserEnteredTrackedDepth::class);
+    Event::assertNotDispatched(event: UserLeftTrackedDepth::class);
+});

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -74,6 +74,7 @@ class TestCase extends Orchestra
             'add_multipliers_column_to_experience_audits_table',
             'create_challenges_table',
             'create_challenge_user_table',
+            'create_leaderboard_snapshots_table',
         ];
 
         foreach ($migrations as $migrationFile) {


### PR DESCRIPTION
## What's new

Challenges can now reward finishing top N on a leaderboard. A new `leaderboard_rank` condition type names a declared Board and a target rank, and is met when the user's rank on that Board — as recorded by the latest snapshot run — is at or above the target (`rank <= N`).

```php
Challenge::create([
    'name' => 'Podium Finish',
    'description' => 'Crack the top 3 on the weekly XP board.',
    'conditions' => [
        ['type' => 'leaderboard_rank', 'board' => 'weekly-xp', 'rank' => 3],
    ],
    'rewards' => [
        ['type' => 'points', 'amount' => 500],
    ],
    'auto_enroll' => true,
]);
```

## How it progresses

Progress is driven by the rank events the snapshot run dispatches: `LeaderboardRankChanged` and `UserEnteredTrackedDepth` now trigger the same challenge-progress evaluation as points, levels, achievements, streaks, and tiers. Completion goes through the normal challenge flow — rewards dispatch, `ChallengeCompleted` fires, repeatable challenges reset.

> [!IMPORTANT]
> This condition only progresses when `level-up:snapshot-boards` runs — schedule it. The rank is read from the latest snapshot rows (not computed live), so a Board that is never snapshotted never satisfies the condition.

`UserLeftTrackedDepth` is deliberately **not** a trigger: leaving the tracked depth means the user's rank got *worse* than `track_top`, and since a valid target rank is always within the tracked depth, that event can never newly satisfy a rank condition.

## Validation — loud, at creation time

Conditions are validated when the challenge is saved, so a misconfigured condition throws an `InvalidArgumentException` instead of silently never completing:

- `board` must be a Board declared in `level-up.leaderboard.boards`
- `rank` must be a positive integer within the Board's tracked depth (`track_top`, default 100) — targeting rank 150 on a board tracking the top 100 is rejected, because below the tracked depth the board is silent and the condition could never be met

This reuses the existing condition-validation seam (`Challenge::saving` → `validateConditions()`), the same place `custom` condition classes are checked.

## Docs

- README: `leaderboard_rank` added to the condition-types table, plus a new "Leaderboard Rank Conditions" section with the example, the snapshot-scheduling dependency, and the validation rules
- Boost skill (`SKILL.md`): condition table and snapshot dependency note updated

Stacked on #167 (`feat/v3-leaderboard-snapshots`).

Closes #155