### PR TITLE
feat(v3): Leagues — Divisions and lazy Cohort enrollment

### DIFF
--- a/README.md
+++ b/README.md
@@ -810,6 +810,59 @@ Rank by anything you can express as a SQL score: implement `LevelUp\Experience\C
 
 To support time periods too, also implement `LevelUp\Experience\Contracts\Windowable` — a `windowedScoreExpression($start, $end)` subquery yielding one numeric score per user for activity between the two timestamps (`$end` may be `null` for an open-ended `since()` range).
 
+### Leagues
+
+A **League** is a competitive cycle built on one periodic Board: each period, active users are grouped into small **Cohorts** within a **Division**, and ranked against their cohort-mates only. Declare it in config by binding a Board and a ladder of Divisions, ordered bottom to top:
+
+```php
+'leaderboard' => [
+    // ...
+    'league' => [
+        'board' => 'weekly-xp', // must be declared under 'boards' with a 'period'
+        'cohort_size' => 30,
+        'divisions' => [
+            'Bronze' => ['promote' => 10, 'relegate' => 0],
+            'Silver' => ['promote' => 7, 'relegate' => 5],
+            'Gold' => ['promote' => 0, 'relegate' => 5],
+        ],
+    ],
+],
+```
+
+Leave `board` as `null` (the default) and the league machinery stays dormant. The configuration is validated loudly: binding a Board that isn't declared throws `BoardNotFoundException`, binding a Board without a `period` throws `LeagueBoardNotPeriodicException` (a league is a cycle — an all-time board cannot host one), and declaring a league with no divisions throws `LeagueDivisionsNotDeclaredException`. Each division's `promote` and `relegate` counts are stored now and consumed by the period rollover (promotion/relegation arrives in a later release).
+
+#### A Division is not a Tier
+
+The two ladders look similar but answer different questions. A **Tier** is *status*: a pure function of your current XP, recalculated whenever your points change. A **Division** is *competition history*: you hold it because of where you placed in last period's cohort, regardless of what your XP is today. A user holds a Tier and competes in a Division simultaneously and independently — adding leagues changes nothing about `HasTiers`, tier columns, or tier events. It's perfectly normal (Duolingo-style) for an app to show a permanent Gold *tier* badge while the user grinds through the Silver *division* this week.
+
+#### Lazy enrollment
+
+Nobody is pre-assigned. A user joins the current period's league on their **first score-earning action** of the period (the `PointsIncreased` event path) — they're placed into the open cohort of their Division, cohorts fill in arrival order, and a new cohort opens when one reaches `cohort_size`. That means:
+
+- **Ghosts are never cohorted.** A user with no qualifying activity in the period appears in no cohort — their Division simply carries over. Relegation (when it arrives) punishes losing, not absence.
+- **New users enter the bottom Division** on their first earn; returning users re-enter the Division they held.
+- **Cohort sizes vary** — the last cohort of a period may be small. Accepted behavior; no skill matching, no backfilling.
+
+The division ladder rows are seeded automatically from config the first time they're needed.
+
+#### User API
+
+Add the `HasLeagues` trait to your user model:
+
+```php
+use LevelUp\Experience\Concerns\HasLeagues;
+```
+
+```php
+$user->currentDivision();   // ?Division — the rung they hold (null until first-ever earn)
+$user->currentCohort();     // ?Cohort — this period's cohort (null if not yet enrolled this period)
+$user->cohortStandings();   // Collection<LeaderboardEntry> — ranked entries within the user's cohort only
+```
+
+`cohortStandings()` runs the league's Board restricted to the user's cohort-mates, so scores and ranks use the Board's own metric and period — rank 1 means first *in the cohort*, not globally. It returns an empty collection for users not in a cohort (and when no league is configured).
+
+The `divisions`, `cohorts`, and `cohort_user` tables ship as package migrations — re-publish migrations and migrate when upgrading.
+
 ## 🔍 Auditing
 
 Auditing keeps track each time a User gains points, levels up and what level to. It is **enabled by default** (since v3) because periodic leaderboards source their scores from the audit ledger — set `AUDIT_POINTS=false` (or `level-up.audit.enabled`) to turn it off if you don't need point history or time-windowed boards.

--- a/config/level-up.php
+++ b/config/level-up.php
@@ -22,6 +22,7 @@ return [
         'leaderboard_snapshot' => LevelUp\Experience\Models\LeaderboardSnapshot::class,
         'division' => LevelUp\Experience\Models\Division::class,
         'cohort' => LevelUp\Experience\Models\Cohort::class,
+        'cohort_user' => LevelUp\Experience\Models\Pivots\CohortUser::class,
     ],
 
     /*

--- a/config/level-up.php
+++ b/config/level-up.php
@@ -20,6 +20,8 @@ return [
         'challenge' => LevelUp\Experience\Models\Challenge::class,
         'challenge_user' => LevelUp\Experience\Models\Pivots\ChallengeUser::class,
         'leaderboard_snapshot' => LevelUp\Experience\Models\LeaderboardSnapshot::class,
+        'division' => LevelUp\Experience\Models\Division::class,
+        'cohort' => LevelUp\Experience\Models\Cohort::class,
     ],
 
     /*
@@ -100,6 +102,9 @@ return [
         'challenges' => 'challenges',
         'challenge_user' => 'challenge_user',
         'leaderboard_snapshots' => 'leaderboard_snapshots',
+        'divisions' => 'divisions',
+        'cohorts' => 'cohorts',
+        'cohort_user' => 'cohort_user',
     ],
 
     /*
@@ -128,6 +133,25 @@ return [
     | 'snapshots.retention_days' controls how long snapshot runs are
     | kept; the level-up:snapshot-boards command prunes older runs.
     |
+    | 'league' declares the League — a competitive cycle built on one
+    | periodic Board. 'board' names the Board users compete on (it must
+    | be declared under 'boards' and have a 'period'); leave it null and
+    | the league machinery stays dormant. 'cohort_size' caps how many
+    | users share a Cohort (default 30). 'divisions' is the ladder,
+    | ordered bottom to top; each entry maps a Division name to its
+    | 'promote' and 'relegate' counts, which are read by the rollover
+    | (arriving in a later release). For example:
+    |
+    | 'league' => [
+    |     'board' => 'weekly-xp',
+    |     'cohort_size' => 30,
+    |     'divisions' => [
+    |         'Bronze' => ['promote' => 10, 'relegate' => 0],
+    |         'Silver' => ['promote' => 7, 'relegate' => 5],
+    |         'Gold' => ['promote' => 0, 'relegate' => 5],
+    |     ],
+    | ],
+    |
     */
     'leaderboard' => [
         'default_metric' => 'xp',
@@ -141,6 +165,11 @@ return [
         'boards' => [],
         'snapshots' => [
             'retention_days' => 30,
+        ],
+        'league' => [
+            'board' => null,
+            'cohort_size' => 30,
+            'divisions' => [],
         ],
         'week_starts_on' => Carbon\CarbonInterface::MONDAY,
         'timezone' => null,

--- a/database/migrations/create_cohort_user_table.php.stub
+++ b/database/migrations/create_cohort_user_table.php.stub
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create(config('level-up.tables.cohort_user'), function (Blueprint $table) {
+            $table->entityId();
+            $table->userForeignId()->constrained(config('level-up.user.users_table'));
+            $table->entityForeignId(column: 'cohort_id')->constrained(table: config('level-up.tables.cohorts'));
+            $table->timestamps();
+
+            $table->unique([config('level-up.user.foreign_key'), 'cohort_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists(config('level-up.tables.cohort_user'));
+    }
+};

--- a/database/migrations/create_cohorts_table.php.stub
+++ b/database/migrations/create_cohorts_table.php.stub
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create(config('level-up.tables.cohorts'), function (Blueprint $table) {
+            $table->entityId();
+            $table->entityForeignId(column: 'division_id')->constrained(table: config('level-up.tables.divisions'));
+            $table->timestamp(column: 'period_start');
+            $table->timestamp(column: 'period_end');
+            $table->timestamps();
+
+            $table->index(['division_id', 'period_start']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists(config('level-up.tables.cohorts'));
+    }
+};

--- a/database/migrations/create_divisions_table.php.stub
+++ b/database/migrations/create_divisions_table.php.stub
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create(config('level-up.tables.divisions'), function (Blueprint $table) {
+            $table->entityId();
+            $table->string(column: 'name')->unique();
+            $table->unsignedInteger(column: 'position')->unique();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists(config('level-up.tables.divisions'));
+    }
+};

--- a/resources/boost/skills/level-up-development/SKILL.md
+++ b/resources/boost/skills/level-up-development/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: level-up-development
-description: Build and work with cjmellor/level-up features, including XP, levels, tiers, achievements, streaks, multipliers, leaderboards, and auditing.
+description: Build and work with cjmellor/level-up features, including XP, levels, tiers, achievements, streaks, multipliers, leaderboards, leagues, and auditing.
 ---
 
 ## When to use this skill
 
-Use this skill when working with gamification features — adding experience points, levels, tiers, achievements, streaks, multipliers, leaderboards, or auditing — using cjmellor/level-up.
+Use this skill when working with gamification features — adding experience points, levels, tiers, achievements, streaks, multipliers, leaderboards, leagues, or auditing — using cjmellor/level-up.
 
 ## Core Concepts
 
@@ -15,6 +15,7 @@ Use this skill when working with gamification features — adding experience poi
 - **Streaks** — Track consecutive daily activities with freeze support.
 - **Multipliers** — Database-backed point modifiers with scoping, scheduling, and configurable stacking strategies.
 - **Leaderboard** — Rank users by any metric (XP by default) with competition-style rank numbers, optionally scoped to a tier or a time period (day/week/month/custom).
+- **Leagues** — A competitive cycle on one periodic Board: active users are grouped into small Cohorts within a Division each period and ranked within their Cohort. A Division is competition history, NOT a Tier (which is XP status) — a user holds both independently.
 - **Auditing** — Automatic history of all XP changes, level-ups, and tier changes.
 
 ## Setup
@@ -36,6 +37,7 @@ Add only the traits you need:
 use LevelUp\Experience\Concerns\GiveExperience;
 use LevelUp\Experience\Concerns\HasAchievements;
 use LevelUp\Experience\Concerns\HasChallenges;
+use LevelUp\Experience\Concerns\HasLeagues;
 use LevelUp\Experience\Concerns\HasStreaks;
 use LevelUp\Experience\Concerns\HasTiers;
 
@@ -46,6 +48,7 @@ class User extends Authenticatable
     use HasStreaks;          // Optional — streaks
     use HasTiers;           // Optional — tiers
     use HasChallenges;      // Optional — challenges
+    use HasLeagues;         // Optional — leagues (divisions/cohorts)
 }
 ```
 
@@ -591,7 +594,7 @@ Period boundary config under `level-up.leaderboard`: `week_starts_on` (Carbon da
 
 ### Named Boards
 
-A **Board** is a *declared* leaderboard — a named metric/period(/tier) combination registered in config — as opposed to an ad-hoc fluent query (composed, executed, forgotten). Only declared Boards are tracked over time (snapshots, rank events; leagues — later releases); declaring none means none of that machinery activates.
+A **Board** is a *declared* leaderboard — a named metric/period(/tier) combination registered in config — as opposed to an ad-hoc fluent query (composed, executed, forgotten). Only declared Boards are tracked over time (snapshots, rank events, leagues); declaring none means none of that machinery activates.
 
 ```php
 'leaderboard' => [
@@ -609,6 +612,36 @@ A **Board** is a *declared* leaderboard — a named metric/period(/tier) combina
 A **Snapshot** persists a Board's top `track_top` entries at a point in time (the `leaderboard_snapshots` table, `LeaderboardSnapshot` model: `board`, `user_id`, `rank`, `score`, `run_at`). The `level-up:snapshot-boards` command snapshots every declared Board, diffs against that Board's previous run, dispatches rank events, and prunes runs older than `level-up.leaderboard.snapshots.retention_days` (default 30). The host schedules it (e.g. `Schedule::command('level-up:snapshot-boards')->hourly()` in `routes/console.php`) — the package never auto-registers scheduler entries.
 
 Diff semantics: rank movement within the tracked depth → `LeaderboardRankChanged`; crossing the boundary → `UserEnteredTrackedDepth` / `UserLeftTrackedDepth`; below the tracked depth a Board is **silent by design** (no rows, no events — don't "fix" this). The first run of a Board is silent (no previous run, no delta). A re-run within the same instant replaces that run's rows (a run is identified by `run_at` to the second) and recomputes the same diff. Snapshots are *not* a cache — `rankOf()`/`around()` always compute fresh at any depth.
+
+### Leagues
+
+A **League** is a competitive cycle on one periodic Board: users are grouped into small **Cohorts** within a **Division** each Period, ranked within their Cohort. Declared under `level-up.leaderboard.league`:
+
+```php
+'league' => [
+    'board' => 'weekly-xp', // must be a declared Board with a 'period'; null (default) = dormant
+    'cohort_size' => 30,
+    'divisions' => [        // the ladder, ordered bottom to top
+        'Bronze' => ['promote' => 10, 'relegate' => 0],
+        'Silver' => ['promote' => 7, 'relegate' => 5],
+        'Gold' => ['promote' => 0, 'relegate' => 5],
+    ],
+],
+```
+
+`promote`/`relegate` counts are stored for the period rollover (a later release). Validation is loud, on first enrollment: undeclared board → `BoardNotFoundException`; board without a `period` → `LeagueBoardNotPeriodicException`; empty `divisions` → `LeagueDivisionsNotDeclaredException`.
+
+**A Division is NOT a Tier.** Tier = pure function of current XP (status). Division = path-dependent competition history (held via cohort placement). A user holds a Tier and competes in a Division simultaneously and independently — `HasTiers`, `experiences.tier_id`, and tier events are untouched by leagues. Never conflate the two ladders.
+
+**Lazy enrollment** (do not "fix" this): a user joins the current period's league on their first score-earning action (`PointsIncreased` listener), entering the open cohort of their Division; cohorts fill in arrival order and a new one opens at `cohort_size`. Ghosts (no qualifying activity in the period) are never cohorted and their Division carries over. New users enter the bottom Division; returning users re-enter the Division they held. Cohort sizes vary — the last cohort of a period may be small. No skill matching. Division rows (`divisions` table) are seeded from config on first need; cohorts live in `cohorts` + `cohort_user`.
+
+```php
+$user->currentDivision();   // ?Division — held rung; null until first-ever earn
+$user->currentCohort();     // ?Cohort — this period's cohort; null until enrolled this period
+$user->cohortStandings();   // Collection<LeaderboardEntry> ranked within the user's cohort only
+```
+
+`cohortStandings()` runs the league Board restricted to the cohort's members — rank 1 is first in the cohort, not globally. Empty collection when not cohorted or no league configured. Requires the `HasLeagues` trait.
 
 ## Auditing
 

--- a/src/Concerns/HasLeagues.php
+++ b/src/Concerns/HasLeagues.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LevelUp\Experience\Concerns;
+
+use Illuminate\Support\Collection;
+use LevelUp\Experience\Models\Cohort;
+use LevelUp\Experience\Models\Division;
+use LevelUp\Experience\Services\LeagueService;
+use LevelUp\Experience\Support\LeaderboardEntry;
+
+trait HasLeagues
+{
+    public function currentDivision(): ?Division
+    {
+        return resolve(name: LeagueService::class)->divisionFor(user: $this);
+    }
+
+    public function currentCohort(): ?Cohort
+    {
+        return resolve(name: LeagueService::class)->cohortFor(user: $this);
+    }
+
+    /**
+     * @return Collection<int, LeaderboardEntry>
+     */
+    public function cohortStandings(): Collection
+    {
+        return resolve(name: LeagueService::class)->standingsFor(user: $this);
+    }
+}

--- a/src/Exceptions/BoardNotFoundException.php
+++ b/src/Exceptions/BoardNotFoundException.php
@@ -12,4 +12,9 @@ final class BoardNotFoundException extends Exception
     {
         return new self(message: "No leaderboard Board is declared for name [{$name}]. Declare it under 'level-up.leaderboard.boards'.");
     }
+
+    public static function forLeague(string $name): self
+    {
+        return new self(message: "The league references the Board [{$name}], but no such Board is declared. Declare it under 'level-up.leaderboard.boards'.");
+    }
 }

--- a/src/Exceptions/LeagueBoardNotPeriodicException.php
+++ b/src/Exceptions/LeagueBoardNotPeriodicException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LevelUp\Experience\Exceptions;
+
+use Exception;
+
+final class LeagueBoardNotPeriodicException extends Exception
+{
+    public static function forBoard(string $name): self
+    {
+        return new self(message: "The league references the Board [{$name}], but it does not declare a period. A League is a competitive cycle — declare a 'period' ('day', 'week', or 'month') on the Board, or bind the league to a periodic Board.");
+    }
+}

--- a/src/Exceptions/LeagueDivisionsNotDeclaredException.php
+++ b/src/Exceptions/LeagueDivisionsNotDeclaredException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LevelUp\Experience\Exceptions;
+
+use Exception;
+
+final class LeagueDivisionsNotDeclaredException extends Exception
+{
+    public static function make(): self
+    {
+        return new self(message: "The league declares no divisions. Declare the ladder bottom to top under 'level-up.leaderboard.league.divisions'.");
+    }
+}

--- a/src/LevelUpServiceProvider.php
+++ b/src/LevelUpServiceProvider.php
@@ -33,6 +33,9 @@ class LevelUpServiceProvider extends PackageServiceProvider
             'challenges' => 'challenges',
             'challenge_user' => 'challenge_user',
             'leaderboard_snapshots' => 'leaderboard_snapshots',
+            'divisions' => 'divisions',
+            'cohorts' => 'cohorts',
+            'cohort_user' => 'cohort_user',
         ];
 
         $resolved = [];
@@ -90,6 +93,9 @@ class LevelUpServiceProvider extends PackageServiceProvider
                 'create_challenges_table',
                 'create_challenge_user_table',
                 'create_leaderboard_snapshots_table',
+                'create_divisions_table',
+                'create_cohorts_table',
+                'create_cohort_user_table',
             ]);
     }
 

--- a/src/Listeners/LeagueEnrollmentListener.php
+++ b/src/Listeners/LeagueEnrollmentListener.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LevelUp\Experience\Listeners;
+
+use LevelUp\Experience\Events\PointsIncreased;
+use LevelUp\Experience\Services\LeagueService;
+
+class LeagueEnrollmentListener
+{
+    public function __invoke(PointsIncreased $event): void
+    {
+        resolve(name: LeagueService::class)->enroll(user: $event->user);
+    }
+}

--- a/src/Models/Cohort.php
+++ b/src/Models/Cohort.php
@@ -42,14 +42,18 @@ class Cohort extends Model
     }
 
     /**
-     * @return BelongsToMany<Model, $this>
+     * @return BelongsToMany<Model, $this, Pivots\CohortUser, 'pivot'>
      */
     public function users(): BelongsToMany
     {
         /** @var class-string<Model> $userClass */
         $userClass = config(key: 'level-up.user.model');
 
+        /** @var class-string<Pivots\CohortUser> $pivotClass */
+        $pivotClass = config(key: 'level-up.models.cohort_user');
+
         return $this->belongsToMany(related: $userClass, table: config('level-up.tables.cohort_user'))
+            ->using($pivotClass)
             ->withTimestamps();
     }
 

--- a/src/Models/Cohort.php
+++ b/src/Models/Cohort.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LevelUp\Experience\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use LevelUp\Experience\Concerns\HasConfigurableIds;
+use LevelUp\Experience\Concerns\ResolvesConfiguredTable;
+
+/**
+ * @property int|string $id
+ * @property int|string $division_id
+ * @property \Illuminate\Support\Carbon $period_start
+ * @property \Illuminate\Support\Carbon $period_end
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read Division $division
+ */
+class Cohort extends Model
+{
+    use HasConfigurableIds, ResolvesConfiguredTable;
+
+    protected $guarded = [];
+
+    protected $casts = [
+        'period_start' => 'datetime',
+        'period_end' => 'datetime',
+    ];
+
+    /**
+     * @return BelongsTo<Division, $this>
+     */
+    public function division(): BelongsTo
+    {
+        /** @var class-string<Division> $divisionClass */
+        $divisionClass = config(key: 'level-up.models.division');
+
+        return $this->belongsTo(related: $divisionClass, foreignKey: 'division_id');
+    }
+
+    /**
+     * @return BelongsToMany<Model, $this>
+     */
+    public function users(): BelongsToMany
+    {
+        /** @var class-string<Model> $userClass */
+        $userClass = config(key: 'level-up.user.model');
+
+        return $this->belongsToMany(related: $userClass, table: config('level-up.tables.cohort_user'))
+            ->withTimestamps();
+    }
+
+    protected function configuredTableKey(): string
+    {
+        return 'cohorts';
+    }
+}

--- a/src/Models/Division.php
+++ b/src/Models/Division.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LevelUp\Experience\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use LevelUp\Experience\Concerns\HasConfigurableIds;
+use LevelUp\Experience\Concerns\ResolvesConfiguredTable;
+
+/**
+ * @property int|string $id
+ * @property string $name
+ * @property int $position
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ */
+class Division extends Model
+{
+    use HasConfigurableIds, ResolvesConfiguredTable;
+
+    protected $guarded = [];
+
+    protected $casts = [
+        'position' => 'integer',
+    ];
+
+    /**
+     * @return HasMany<Cohort, $this>
+     */
+    public function cohorts(): HasMany
+    {
+        /** @var class-string<Cohort> $cohortClass */
+        $cohortClass = config(key: 'level-up.models.cohort');
+
+        return $this->hasMany(related: $cohortClass, foreignKey: 'division_id');
+    }
+
+    protected function configuredTableKey(): string
+    {
+        return 'divisions';
+    }
+}

--- a/src/Models/Pivots/CohortUser.php
+++ b/src/Models/Pivots/CohortUser.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LevelUp\Experience\Models\Pivots;
+
+use Illuminate\Database\Eloquent\Relations\Pivot;
+use LevelUp\Experience\Concerns\HasConfigurableIds;
+use LevelUp\Experience\Concerns\ResolvesConfiguredTable;
+
+/**
+ * @property int|string|null $next_division_id
+ */
+class CohortUser extends Pivot
+{
+    use HasConfigurableIds, ResolvesConfiguredTable;
+
+    protected function configuredTableKey(): string
+    {
+        return 'cohort_user';
+    }
+}

--- a/src/Providers/EventServiceProvider.php
+++ b/src/Providers/EventServiceProvider.php
@@ -14,6 +14,7 @@ use LevelUp\Experience\Events\UserEnteredTrackedDepth;
 use LevelUp\Experience\Events\UserLevelledUp;
 use LevelUp\Experience\Events\UserTierUpdated;
 use LevelUp\Experience\Listeners\ChallengeProgressListener;
+use LevelUp\Experience\Listeners\LeagueEnrollmentListener;
 use LevelUp\Experience\Listeners\PointsDecreasedListener;
 use LevelUp\Experience\Listeners\PointsIncreasedListener;
 use LevelUp\Experience\Listeners\UserLevelledUpListener;
@@ -28,6 +29,7 @@ class EventServiceProvider extends ServiceProvider
         PointsIncreased::class => [
             PointsIncreasedListener::class,
             ChallengeProgressListener::class,
+            LeagueEnrollmentListener::class,
         ],
         UserLevelledUp::class => [
             UserLevelledUpListener::class,

--- a/src/Services/LeagueService.php
+++ b/src/Services/LeagueService.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LevelUp\Experience\Services;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
+use LevelUp\Experience\Enums\Period;
+use LevelUp\Experience\Exceptions\BoardNotFoundException;
+use LevelUp\Experience\Exceptions\LeagueBoardNotPeriodicException;
+use LevelUp\Experience\Exceptions\LeagueDivisionsNotDeclaredException;
+use LevelUp\Experience\Models\Cohort;
+use LevelUp\Experience\Models\Division;
+use LevelUp\Experience\Support\LeaderboardEntry;
+use LevelUp\Experience\Support\PeriodRange;
+
+class LeagueService
+{
+    public function configured(): bool
+    {
+        $board = config(key: 'level-up.leaderboard.league.board');
+
+        return is_string($board) && $board !== '';
+    }
+
+    public function enroll(Model $user): void
+    {
+        if (! $this->configured()) {
+            return;
+        }
+
+        $range = $this->currentRange();
+
+        if ($this->cohortForRange(user: $user, range: $range) instanceof Cohort) {
+            return;
+        }
+
+        $latestCohort = $this->latestCohortFor(user: $user);
+        $division = $latestCohort instanceof Cohort ? $latestCohort->division : $this->bottomDivision();
+
+        $this->openCohort(division: $division, range: $range)->users()->attach($user->getKey());
+    }
+
+    public function cohortFor(Model $user): ?Cohort
+    {
+        if (! $this->configured()) {
+            return null;
+        }
+
+        return $this->cohortForRange(user: $user, range: $this->currentRange());
+    }
+
+    public function divisionFor(Model $user): ?Division
+    {
+        if (! $this->configured()) {
+            return null;
+        }
+
+        return $this->latestCohortFor(user: $user)?->division;
+    }
+
+    /**
+     * @return Collection<int, LeaderboardEntry>
+     */
+    public function standingsFor(Model $user): Collection
+    {
+        $cohort = $this->cohortFor(user: $user);
+
+        if (! $cohort instanceof Cohort) {
+            return new Collection();
+        }
+
+        $memberKeys = $cohort->users()->pluck(column: $user->getQualifiedKeyName())->all();
+
+        /** @var Collection<int, LeaderboardEntry> $entries */
+        $entries = resolve(name: LeaderboardService::class)
+            ->board(name: config()->string(key: 'level-up.leaderboard.league.board'))
+            ->restrictTo(constraint: fn (Builder $query): Builder => $query->whereKey(id: $memberKeys))
+            ->generate();
+
+        return $entries;
+    }
+
+    private function currentRange(): PeriodRange
+    {
+        return $this->boardPeriod()->range();
+    }
+
+    private function boardPeriod(): Period
+    {
+        $board = config()->string(key: 'level-up.leaderboard.league.board');
+        $boards = config()->array(key: 'level-up.leaderboard.boards');
+        $declaration = $boards[$board] ?? null;
+
+        throw_unless(is_array($declaration), exception: BoardNotFoundException::forLeague($board));
+
+        $period = $declaration['period'] ?? null;
+
+        throw_if($period === null, exception: LeagueBoardNotPeriodicException::forBoard($board));
+
+        return $period instanceof Period ? $period : Period::from(value: is_string($period) ? $period : '');
+    }
+
+    private function cohortForRange(Model $user, PeriodRange $range): ?Cohort
+    {
+        return $this->cohortQuery()
+            ->where(column: 'period_start', operator: '=', value: $range->start)
+            ->whereHas(relation: 'users', callback: fn (Builder $query): Builder => $query->whereKey($user->getKey()))
+            ->first();
+    }
+
+    private function latestCohortFor(Model $user): ?Cohort
+    {
+        return $this->cohortQuery()
+            ->whereHas(relation: 'users', callback: fn (Builder $query): Builder => $query->whereKey($user->getKey()))
+            ->orderByDesc(column: 'period_start')
+            ->first();
+    }
+
+    private function bottomDivision(): Division
+    {
+        return $this->syncDivisions()->firstOrFail();
+    }
+
+    /**
+     * @return Collection<int, Division>
+     */
+    private function syncDivisions(): Collection
+    {
+        $declared = config()->array(key: 'level-up.leaderboard.league.divisions');
+
+        throw_if($declared === [], exception: LeagueDivisionsNotDeclaredException::make());
+
+        /** @var class-string<Division> $divisionClass */
+        $divisionClass = config(key: 'level-up.models.division');
+
+        $divisions = new Collection();
+        $position = 1;
+
+        foreach (array_keys($declared) as $name) {
+            $divisions->push($divisionClass::query()->firstOrCreate(
+                attributes: ['name' => (string) $name],
+                values: ['position' => $position],
+            ));
+
+            $position++;
+        }
+
+        return $divisions;
+    }
+
+    private function openCohort(Division $division, PeriodRange $range): Cohort
+    {
+        $cohortSize = config()->integer(key: 'level-up.leaderboard.league.cohort_size', default: 30);
+
+        $open = $division->cohorts()
+            ->withCount(relations: 'users')
+            ->where(column: 'period_start', operator: '=', value: $range->start)
+            ->get()
+            ->first(callback: fn (Cohort $cohort): bool => $cohort->users_count < $cohortSize);
+
+        return $open ?? $division->cohorts()->create(attributes: [
+            'period_start' => $range->start,
+            'period_end' => $range->end,
+        ]);
+    }
+
+    /**
+     * @return Builder<Cohort>
+     */
+    private function cohortQuery(): Builder
+    {
+        /** @var class-string<Cohort> $cohortClass */
+        $cohortClass = config(key: 'level-up.models.cohort');
+
+        return $cohortClass::query();
+    }
+}

--- a/tests/Concerns/HasStreaksTest.php
+++ b/tests/Concerns/HasStreaksTest.php
@@ -14,7 +14,11 @@ use function Pest\Laravel\travel;
 
 uses()->group('streaks');
 
-beforeEach(closure: fn () => $this->activity = Activity::factory()->create());
+beforeEach(closure: function (): void {
+    $this->freezeTime();
+
+    $this->activity = Activity::factory()->create();
+});
 
 test(description: 'record a streak if one does not exist for the activity', closure: function (): void {
     Event::fake();

--- a/tests/Config/ResolveTablesTest.php
+++ b/tests/Config/ResolveTablesTest.php
@@ -26,6 +26,9 @@ it('returns defaults when no prefix or overrides are set', function (): void {
         'challenges' => 'challenges',
         'challenge_user' => 'challenge_user',
         'leaderboard_snapshots' => 'leaderboard_snapshots',
+        'divisions' => 'divisions',
+        'cohorts' => 'cohorts',
+        'cohort_user' => 'cohort_user',
     ]);
 });
 

--- a/tests/Fixtures/User.php
+++ b/tests/Fixtures/User.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Eloquent\Model;
 use LevelUp\Experience\Concerns\GiveExperience;
 use LevelUp\Experience\Concerns\HasAchievements;
 use LevelUp\Experience\Concerns\HasChallenges;
+use LevelUp\Experience\Concerns\HasLeagues;
 use LevelUp\Experience\Concerns\HasStreaks;
 use LevelUp\Experience\Concerns\HasTiers;
 use LevelUp\Experience\Tests\Fixtures\Factories\UserFactory;
@@ -20,6 +21,7 @@ class User extends Model
     use HasAchievements;
     use HasChallenges;
     use HasFactory;
+    use HasLeagues;
     use HasStreaks;
     use HasTiers;
 

--- a/tests/Migrations/TablePrefixIntegrationTest.php
+++ b/tests/Migrations/TablePrefixIntegrationTest.php
@@ -32,6 +32,9 @@ class TablePrefixIntegrationTest extends TestCase
         $this->assertTrue(Schema::hasTable('pfx_challenges'));
         $this->assertTrue(Schema::hasTable('pfx_challenge_user'));
         $this->assertTrue(Schema::hasTable('pfx_leaderboard_snapshots'));
+        $this->assertTrue(Schema::hasTable('pfx_divisions'));
+        $this->assertTrue(Schema::hasTable('pfx_cohorts'));
+        $this->assertTrue(Schema::hasTable('pfx_cohort_user'));
     }
 
     public function test_explicit_override_escapes_the_prefix(): void

--- a/tests/Services/LeagueTest.php
+++ b/tests/Services/LeagueTest.php
@@ -1,0 +1,214 @@
+<?php
+
+declare(strict_types=1);
+
+uses()->group('league');
+
+use Illuminate\Support\Facades\Date;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Event;
+use LevelUp\Experience\Events\UserTierUpdated;
+use LevelUp\Experience\Exceptions\BoardNotFoundException;
+use LevelUp\Experience\Exceptions\LeagueBoardNotPeriodicException;
+use LevelUp\Experience\Exceptions\LeagueDivisionsNotDeclaredException;
+use LevelUp\Experience\Models\Cohort;
+use LevelUp\Experience\Models\Division;
+use LevelUp\Experience\Models\Tier;
+use LevelUp\Experience\Tests\Fixtures\User;
+
+beforeEach(function (): void {
+    config(['level-up.user.model' => User::class]);
+    config(['level-up.multiplier.enabled' => false]);
+});
+
+function configureLeague(int $cohortSize = 30): void
+{
+    config(['level-up.leaderboard.boards' => [
+        'weekly-xp' => ['metric' => 'xp', 'period' => 'week'],
+    ]]);
+
+    config(['level-up.leaderboard.league' => [
+        'board' => 'weekly-xp',
+        'cohort_size' => $cohortSize,
+        'divisions' => [
+            'Bronze' => ['promote' => 10, 'relegate' => 0],
+            'Silver' => ['promote' => 7, 'relegate' => 5],
+            'Gold' => ['promote' => 0, 'relegate' => 5],
+        ],
+    ]]);
+}
+
+it(description: 'enrolls a user into a cohort in the bottom division on their first earn', closure: function (): void {
+    configureLeague();
+
+    $user = User::newFactory()->create();
+    $user->addPoints(amount: 50);
+
+    $cohort = $user->currentCohort();
+
+    expect($cohort)->toBeInstanceOf(class: Cohort::class)
+        ->and($user->currentDivision()?->name)->toBe(expected: 'Bronze')
+        ->and($cohort->users()->count())->toBe(expected: 1);
+});
+
+it(description: 'does not re-enroll a user on subsequent earns in the same period', closure: function (): void {
+    configureLeague();
+
+    $user = User::newFactory()->create();
+    $user->addPoints(amount: 50);
+    $user->addPoints(amount: 25);
+
+    expect(Cohort::query()->count())->toBe(expected: 1)
+        ->and(DB::table(table: 'cohort_user')->count())->toBe(expected: 1);
+});
+
+it(description: 'fills the open cohort in arrival order until it reaches cohort_size', closure: function (): void {
+    configureLeague(cohortSize: 2);
+
+    $first = tap(User::newFactory()->create())->addPoints(amount: 10);
+    $second = tap(User::newFactory()->create())->addPoints(amount: 20);
+
+    expect(Cohort::query()->count())->toBe(expected: 1)
+        ->and($first->currentCohort()?->id)->toEqual($second->currentCohort()?->id);
+});
+
+it(description: 'opens a new cohort in the same division when the open cohort is full', closure: function (): void {
+    configureLeague(cohortSize: 2);
+
+    $first = tap(User::newFactory()->create())->addPoints(amount: 10);
+    tap(User::newFactory()->create())->addPoints(amount: 20);
+    $overflow = tap(User::newFactory()->create())->addPoints(amount: 30);
+
+    expect(Cohort::query()->count())->toBe(expected: 2)
+        ->and($overflow->currentCohort()?->id)->not->toEqual($first->currentCohort()?->id)
+        ->and($overflow->currentDivision()?->name)->toBe(expected: 'Bronze')
+        ->and($overflow->currentCohort()?->users()->count())->toBe(expected: 1);
+});
+
+it(description: 'never cohorts a ghost — a user with no qualifying activity in the period', closure: function (): void {
+    configureLeague();
+
+    tap(User::newFactory()->create())->addPoints(amount: 50);
+    $ghost = User::newFactory()->create();
+
+    expect($ghost->currentCohort())->toBeNull()
+        ->and($ghost->currentDivision())->toBeNull()
+        ->and(DB::table(table: 'cohort_user')->count())->toBe(expected: 1);
+});
+
+it(description: "carries a ghost's division across periods without cohorting them", closure: function (): void {
+    configureLeague();
+
+    $this->travelTo(Date::parse(time: '2026-06-03 12:00:00'));
+    $user = tap(User::newFactory()->create())->addPoints(amount: 50);
+
+    $this->travelTo(Date::parse(time: '2026-06-10 12:00:00'));
+
+    expect($user->currentCohort())->toBeNull()
+        ->and($user->currentDivision()?->name)->toBe(expected: 'Bronze');
+});
+
+it(description: 'enrolls a returning user into their held division, not the bottom one', closure: function (): void {
+    configureLeague();
+
+    Division::query()->create(attributes: ['name' => 'Bronze', 'position' => 1]);
+    $silver = Division::query()->create(attributes: ['name' => 'Silver', 'position' => 2]);
+
+    $this->travelTo(Date::parse(time: '2026-06-03 12:00:00'));
+    $user = User::newFactory()->create();
+
+    $lastWeek = Cohort::query()->create(attributes: [
+        'division_id' => $silver->id,
+        'period_start' => Date::parse(time: '2026-06-01 00:00:00'),
+        'period_end' => Date::parse(time: '2026-06-08 00:00:00'),
+    ]);
+    $lastWeek->users()->attach($user->id);
+
+    $this->travelTo(Date::parse(time: '2026-06-10 12:00:00'));
+    $user->addPoints(amount: 50);
+
+    expect($user->currentCohort()?->division->name)->toBe(expected: 'Silver');
+});
+
+it(description: 'ranks cohort standings within the cohort only', closure: function (): void {
+    configureLeague(cohortSize: 2);
+
+    $runnerUp = tap(User::newFactory()->create())->addPoints(amount: 50);
+    $leader = tap(User::newFactory()->create())->addPoints(amount: 80);
+    tap(User::newFactory()->create())->addPoints(amount: 500);
+
+    $standings = $runnerUp->cohortStandings();
+
+    expect($standings)->toHaveCount(count: 2)
+        ->and($standings->first()->user->id)->toEqual($leader->id)
+        ->and($standings->first()->rank)->toBe(expected: 1)
+        ->and($standings->first()->score)->toBe(expected: 80)
+        ->and($standings->last()->user->id)->toEqual($runnerUp->id)
+        ->and($standings->last()->rank)->toBe(expected: 2)
+        ->and($standings->last()->score)->toBe(expected: 50);
+});
+
+it(description: 'seeds the division ladder from config, bottom to top', closure: function (): void {
+    configureLeague();
+
+    tap(User::newFactory()->create())->addPoints(amount: 50);
+
+    $ladder = Division::query()->orderBy(column: 'position')->get();
+
+    expect($ladder->pluck('name')->all())->toBe(expected: ['Bronze', 'Silver', 'Gold'])
+        ->and($ladder->pluck('position')->all())->toBe(expected: [1, 2, 3]);
+});
+
+it(description: 'stays dormant when no league is configured', closure: function (): void {
+    $user = User::newFactory()->create();
+    $user->addPoints(amount: 50);
+
+    expect(Cohort::query()->count())->toBe(expected: 0)
+        ->and(Division::query()->count())->toBe(expected: 0)
+        ->and($user->currentCohort())->toBeNull()
+        ->and($user->currentDivision())->toBeNull()
+        ->and($user->cohortStandings())->toBeEmpty();
+});
+
+it(description: 'leaves tier behavior untouched while the user competes in a division', closure: function (): void {
+    configureLeague();
+
+    Event::fake(eventsToFake: [UserTierUpdated::class]);
+
+    Tier::add(
+        ['name' => 'Wood', 'experience' => 0],
+        ['name' => 'Stone', 'experience' => 500],
+    );
+
+    $user = User::newFactory()->create();
+    $user->addPoints(amount: 550);
+
+    expect($user->getTier()?->name)->toBe(expected: 'Stone')
+        ->and($user->experience->tier_id)->toEqual(Tier::query()->where(column: 'name', operator: '=', value: 'Stone')->first()?->id)
+        ->and($user->currentDivision()?->name)->toBe(expected: 'Bronze');
+
+    Event::assertDispatched(event: UserTierUpdated::class, callback: fn (UserTierUpdated $event): bool => $event->newTier?->name === 'Stone');
+});
+
+it(description: 'throws on first earn when the league references an undeclared Board', closure: function (): void {
+    configureLeague();
+    config(['level-up.leaderboard.league.board' => 'missing-board']);
+
+    tap(User::newFactory()->create())->addPoints(amount: 50);
+})->throws(exception: BoardNotFoundException::class, exceptionMessage: "The league references the Board [missing-board], but no such Board is declared. Declare it under 'level-up.leaderboard.boards'.");
+
+it(description: 'throws on first earn when the league references a Board without a period', closure: function (): void {
+    configureLeague();
+    config(['level-up.leaderboard.boards' => [
+        'weekly-xp' => ['metric' => 'xp'],
+    ]]);
+
+    tap(User::newFactory()->create())->addPoints(amount: 50);
+})->throws(exception: LeagueBoardNotPeriodicException::class, exceptionMessage: "The league references the Board [weekly-xp], but it does not declare a period. A League is a competitive cycle — declare a 'period' ('day', 'week', or 'month') on the Board, or bind the league to a periodic Board.");
+
+it(description: 'throws on first earn when the league declares no divisions', closure: function (): void {
+    configureLeague();
+    config(['level-up.leaderboard.league.divisions' => []]);
+
+    tap(User::newFactory()->create())->addPoints(amount: 50);
+})->throws(exception: LeagueDivisionsNotDeclaredException::class, exceptionMessage: "The league declares no divisions. Declare the ladder bottom to top under 'level-up.leaderboard.league.divisions'.");

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -75,6 +75,9 @@ class TestCase extends Orchestra
             'create_challenges_table',
             'create_challenge_user_table',
             'create_leaderboard_snapshots_table',
+            'create_divisions_table',
+            'create_cohorts_table',
+            'create_cohort_user_table',
         ];
 
         foreach ($migrations as $migrationFile) {


### PR DESCRIPTION
Introduces **Leagues** — a competitive cycle built on one periodic Board. Each period, active users are grouped into small **Cohorts** within a **Division** and ranked against their cohort-mates only.

## Declaring a league

```php
'leaderboard' => [
    'league' => [
        'board' => 'weekly-xp', // must be a declared Board with a 'period'
        'cohort_size' => 30,
        'divisions' => [        // the ladder, ordered bottom to top
            'Bronze' => ['promote' => 10, 'relegate' => 0],
            'Silver' => ['promote' => 7, 'relegate' => 5],
            'Gold' => ['promote' => 0, 'relegate' => 5],
        ],
    ],
],
```

Leave `board` as `null` (the default) and the league machinery stays dormant. Validation is loud: binding an undeclared Board throws `BoardNotFoundException`; a Board without a `period` throws `LeagueBoardNotPeriodicException` (a league is a cycle — an all-time board cannot host one); an empty ladder throws `LeagueDivisionsNotDeclaredException`. Division rows are seeded from config automatically the first time they are needed.

## A Division is not a Tier

The two ladders answer different questions. A **Tier** is *status* — a pure function of your current XP, recalculated whenever points change. A **Division** is *competition history* — held because of last period's cohort placement, regardless of today's XP. A user holds a Tier and competes in a Division simultaneously and independently: `HasTiers`, tier columns, and tier events are completely untouched (regression-covered). An app can show a permanent Gold *tier* badge while the user grinds through the Silver *division* this week.

## Lazy enrollment

Nobody is pre-assigned. A user joins the current period's league on their **first score-earning action** of the period (riding the `PointsIncreased` event path):

- Cohorts fill in **arrival order** within each Division; a new cohort opens when one reaches `cohort_size`.
- **Ghosts** — users with no qualifying activity in the period — are never cohorted; their Division carries over.
- **New users** enter the bottom Division on first earn; returning users re-enter the Division they held.
- Cohort sizes vary: the final cohort of a period may be small. No skill matching, no backfilling.

## User API

Add the `HasLeagues` trait to your user model:

```php
$user->currentDivision();   // ?Division — the rung they hold
$user->currentCohort();     // ?Cohort — this period's cohort
$user->cohortStandings();   // Collection<LeaderboardEntry>, ranked within the cohort only
```

`cohortStandings()` runs the league's Board restricted to the user's cohort-mates — rank 1 means first *in the cohort*, not globally.

## Migrations

Three new tables ship as package migrations — `divisions`, `cohorts`, and `cohort_user` — all following the configurable conventions (`level-up.tables.*`, configurable ID types, `userForeignId()`). Re-publish migrations and migrate when upgrading.

## What comes next

The per-division `promote`/`relegate` counts are stored and validated now but consumed by the **period rollover** (promotion, relegation, and movement clamping), which arrives in the next slice.

> Stacked on #168 (`feat/v3-challenge-leaderboard-rank-condition`).

Closes #156
