### PR TITLE
docs(v3): leaderboard and leagues release documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,24 @@ All notable changes to `level-up` will be documented in this file.
 - **`LevelUp\Experience\Support\UserForeignKey` helper class removed.** Replaced by a `$table->userForeignId()` Blueprint macro that reads the same config and routes to `foreignId()` / `foreignUuid()` / `foreignUlid()`.
 - **Trait method aliasing helpers removed** (cherry-picked from v2.1's revert of PR #123). Host User models with colliding `challenges()` / `streaks()` / `experience()` / `experienceHistory()` methods need to rename or compose into a wrapper model.
 - **`setPoints()` recalculates level and tier.** Previously a raw column write with no side effects; now fires `UserLevelledUp` / `UserTierUpdated` events when the new point total implies a different placement.
-- **`level-up.audit.enabled` now defaults to `true`** (was `false`). Time-windowed leaderboards source their scores from the `experience_audits` ledger, so auditing is on out of the box. Set `AUDIT_POINTS=false` to opt out. See UPGRADE.md.
+- **`level-up.audit.enabled` now defaults to `true`** (was `false`). Time-windowed leaderboards source their scores from the `experience_audits` ledger, so auditing is on out of the box. Set `AUDIT_POINTS=false` to opt out — but periodic XP boards then throw `MetricRequiresAuditingException`. See UPGRADE.md. (#163)
+- **`Leaderboard::generate()` returns `LeaderboardEntry` objects** — `$entry->user`, `$entry->score`, `$entry->rank` — instead of a bare collection of `User` models. Score and rank live on the entry, never on the User model. See UPGRADE.md. (#160)
+- **Leaderboard ranks require a window-function-capable database** — SQLite 3.25+ or MySQL 8+; MariaDB 10.2+ and PostgreSQL support window functions natively. MySQL 5.7 (EOL) is not supported. (#161)
 - **Excess points cap at the top level instead of throwing.** `addPoints($amount)` where `$amount` exceeds the highest defined level's threshold no longer throws — the user is capped at the highest level.
 
 ### Added
 
+- **Metric-driven leaderboard** — rank by any metric via the `RankingMetric` contract and `Leaderboard::by()`; built-in metrics are registered in `level-up.leaderboard.metrics`, with `MetricNotFoundException` / `MetricDisabledException` on bad input. (#160)
+- **Rank numbers and ties** — competition semantics (1, 1, 3) computed with SQL window functions, deterministic tiebreak ordering, plus `rankOf()` and `around()`. (#161)
+- **`level` and `streak` state metrics** — rank by current level, or by streak count for an Activity via `new StreakMetric(activity: $activity)`. (#162)
+- **Time Periods** — `period(Period::Day|Week|Month)` and `since(start:, until:)` window a board to activity inside the range; XP windows are sourced from the `experience_audits` ledger; `week_starts_on` / `timezone` config controls boundaries. (#163)
+- **`achievements` and `challenges` flow metrics** — rank by achievements earned (secret ones count) or challenges completed, all-time or per Period. (#164)
+- **`restrictTo()`** — host-defined populations (friends boards, guilds, tournament brackets); ranks are computed within the restricted set. (#165)
+- **Named Boards** — declare metric/period(/tier) combinations under `level-up.leaderboard.boards` and resolve them with `Leaderboard::board()`; only declared Boards are tracked over time. (#166)
+- **Snapshots and rank events** — the `level-up:snapshot-boards` command persists each Board's top entries down to its Tracked Depth (`track_top`, default 100), diffs consecutive runs, dispatches `LeaderboardRankChanged` / `UserEnteredTrackedDepth` / `UserLeftTrackedDepth`, and prunes runs per `snapshots.retention_days`. (#167)
+- **`leaderboard_rank` challenge condition** — "finish top N on a named Board", progressed by snapshot runs and validated against the Board's Tracked Depth at creation. (#168)
+- **Leagues** — a Division ladder with lazy Cohort enrollment on one periodic Board; `HasLeagues` trait with `currentDivision()`, `currentCohort()`, and `cohortStandings()`. (#169)
+- **League rollover** — the `level-up:league-rollover` command computes each Cohort's final standings live, promotes and relegates per the Division's configured counts, and dispatches `UserDivisionChanged`. (#170)
 - `Multiplier::scopeToUser`, `scopeToTier`, `unscopeFromUser`, `unscopeFromTier`, `isGlobal` methods.
 - `$table->userForeignId()` Blueprint macro alongside `entityId()` / `entityForeignId()`.
 - `migrate_multiplier_scopes_to_typed_pivots` migration — backfills v2.x data into the v3 schema, no-op on fresh installs.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,27 @@ This is the contents of the published config file:
 
 ```php
 return [
+
+    'models' => [
+        'achievement' => LevelUp\Experience\Models\Achievement::class,
+        'activity' => LevelUp\Experience\Models\Activity::class,
+        'experience' => LevelUp\Experience\Models\Experience::class,
+        'experience_audit' => LevelUp\Experience\Models\ExperienceAudit::class,
+        'level' => LevelUp\Experience\Models\Level::class,
+        'streak' => LevelUp\Experience\Models\Streak::class,
+        'streak_history' => LevelUp\Experience\Models\StreakHistory::class,
+        'achievement_user' => LevelUp\Experience\Models\Pivots\AchievementUser::class,
+        'tier' => LevelUp\Experience\Models\Tier::class,
+        'multiplier' => LevelUp\Experience\Models\Multiplier::class,
+        'multiplier_user' => LevelUp\Experience\Models\Pivots\MultiplierUser::class,
+        'multiplier_tier' => LevelUp\Experience\Models\Pivots\MultiplierTier::class,
+        'challenge' => LevelUp\Experience\Models\Challenge::class,
+        'challenge_user' => LevelUp\Experience\Models\Pivots\ChallengeUser::class,
+        'leaderboard_snapshot' => LevelUp\Experience\Models\LeaderboardSnapshot::class,
+        'division' => LevelUp\Experience\Models\Division::class,
+        'cohort' => LevelUp\Experience\Models\Cohort::class,
+    ],
+
     /*
     |--------------------------------------------------------------------------
     | User Foreign Key
@@ -40,10 +61,18 @@ return [
     |
     | This value is the foreign key that will be used to relate the Experience model to the User model.
     |
+    | 'foreign_key_type' controls the DB column type used for the user FK on
+    | every package table. Set to 'uuid' or 'ulid' if your host User model
+    | uses HasUuids / HasUlids. Leave as 'bigint' for standard auto-increment
+    | user IDs. This only affects fresh migrations; existing installs keep
+    | whichever column type they originally migrated with.
+    |
      */
     'user' => [
         'foreign_key' => 'user_id',
+        'foreign_key_type' => 'bigint',
         'model' => App\Models\User::class,
+        'users_table' => 'users',
     ],
 
     /*
@@ -51,12 +80,129 @@ return [
     | Package Entities
     |--------------------------------------------------------------------------
     |
-    | Set 'id_type' to 'uuid' or 'ulid' if you want package IDs to be opaque.
-    | Only affects fresh installs — see "Customizing Identifiers" below.
+    | 'id_type' controls the primary key column type used for the package's
+    | own tables (experiences, levels, achievements, etc.) and every internal
+    | foreign key between them. Set to 'uuid' or 'ulid' if you want package
+    | IDs to be opaque (e.g., for safe exposure on a public API surface).
+    | Leave as 'bigint' for standard auto-increment IDs. Only affects fresh
+    | migrations; existing installs keep whichever column type they already
+    | migrated with. See the README "Customizing Identifiers" section for
+    | guidance on switching an existing install.
     |
     */
     'entities' => [
         'id_type' => 'bigint',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Table Prefix
+    |--------------------------------------------------------------------------
+    |
+    | Prepended to every default package table name. Leave empty for no prefix.
+    | Per-table overrides in 'tables' below are taken verbatim and are NOT
+    | prefixed.
+    |
+    */
+    'table_prefix' => env('LEVEL_UP_TABLE_PREFIX', ''),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Tables
+    |--------------------------------------------------------------------------
+    |
+    | The table name used for each of the package's models. Leave a value
+    | equal to the default to apply table_prefix above; set it to any other
+    | string to override that table's name exactly (no prefix applied).
+    |
+    */
+    'tables' => [
+        'experiences' => 'experiences',
+        'experience_audits' => 'experience_audits',
+        'levels' => 'levels',
+        'achievements' => 'achievements',
+        'achievement_user' => 'achievement_user',
+        'streaks' => 'streaks',
+        'streak_histories' => 'streak_histories',
+        'streak_activities' => 'streak_activities',
+        'tiers' => 'tiers',
+        'multipliers' => 'multipliers',
+        'multiplier_user' => 'multiplier_user',
+        'multiplier_tier' => 'multiplier_tier',
+        'challenges' => 'challenges',
+        'challenge_user' => 'challenge_user',
+        'leaderboard_snapshots' => 'leaderboard_snapshots',
+        'divisions' => 'divisions',
+        'cohorts' => 'cohorts',
+        'cohort_user' => 'cohort_user',
+    ],
+
+    /*
+    |-----------------------------------------------------------------------
+    | Leaderboard
+    |-----------------------------------------------------------------------
+    |
+    | Configure the leaderboard. 'metrics' maps registry keys to
+    | RankingMetric classes — register custom metrics by adding entries.
+    | 'default_metric' is used when no metric is specified.
+    |
+    | 'week_starts_on' sets the boundary of Period::Week as a Carbon
+    | day-of-week number: 0 (Sunday) through 6 (Saturday). Defaults to
+    | Monday. 'timezone' controls which timezone period boundaries
+    | (start of day/week/month) are computed in; null uses the
+    | application timezone.
+    |
+    | 'boards' declares named Boards — leaderboards the package can
+    | track over time. Each entry maps a board name to a 'metric'
+    | (required registry key), an optional 'period' ('day', 'week',
+    | or 'month'), an optional 'tier' (a tier name), and an optional
+    | 'track_top' (the tracked depth — how many top entries the
+    | snapshot run stores and events, default 100). For example:
+    | 'weekly-xp' => ['metric' => 'xp', 'period' => 'week'].
+    |
+    | 'snapshots.retention_days' controls how long snapshot runs are
+    | kept; the level-up:snapshot-boards command prunes older runs.
+    |
+    | 'league' declares the League — a competitive cycle built on one
+    | periodic Board. 'board' names the Board users compete on (it must
+    | be declared under 'boards' and have a 'period'); leave it null and
+    | the league machinery stays dormant. 'cohort_size' caps how many
+    | users share a Cohort (default 30). 'divisions' is the ladder,
+    | ordered bottom to top; each entry maps a Division name to its
+    | 'promote' and 'relegate' counts, which are read by the
+    | level-up:league-rollover command at period close. For example:
+    |
+    | 'league' => [
+    |     'board' => 'weekly-xp',
+    |     'cohort_size' => 30,
+    |     'divisions' => [
+    |         'Bronze' => ['promote' => 10, 'relegate' => 0],
+    |         'Silver' => ['promote' => 7, 'relegate' => 5],
+    |         'Gold' => ['promote' => 0, 'relegate' => 5],
+    |     ],
+    | ],
+    |
+    */
+    'leaderboard' => [
+        'default_metric' => 'xp',
+        'metrics' => [
+            'xp' => LevelUp\Experience\Metrics\ExperienceMetric::class,
+            'level' => LevelUp\Experience\Metrics\LevelMetric::class,
+            'streak' => LevelUp\Experience\Metrics\StreakMetric::class,
+            'achievements' => LevelUp\Experience\Metrics\AchievementMetric::class,
+            'challenges' => LevelUp\Experience\Metrics\ChallengeMetric::class,
+        ],
+        'boards' => [],
+        'snapshots' => [
+            'retention_days' => 30,
+        ],
+        'league' => [
+            'board' => null,
+            'cohort_size' => 30,
+            'divisions' => [],
+        ],
+        'week_starts_on' => Carbon\CarbonInterface::MONDAY,
+        'timezone' => null,
     ],
 
     /*
@@ -81,6 +227,9 @@ return [
     'multiplier' => [
         'enabled' => env(key: 'MULTIPLIER_ENABLED', default: true),
         'stack_strategy' => env(key: 'MULTIPLIER_STACK', default: 'compound'),
+        // 'compound'  — multipliers multiply each other: 2 × 5 = 10x
+        // 'additive'  — multipliers sum:              2 + 5 = 7x
+        // 'highest'   — only the largest applies:  max(2, 5) = 5x
     ],
 
     /*
@@ -102,11 +251,13 @@ return [
     | Audit
     | -------------------------------------------------------------------------
     |
-    | Set the audit configuration.
+    | Set the audit configuration. Auditing records every point transaction
+    | in the experience_audits ledger and is required for time-windowed
+    | (periodic) leaderboards. Enabled by default since v3.
     |
     */
     'audit' => [
-        'enabled' => env(key: 'AUDIT_POINTS', default: false),
+        'enabled' => env(key: 'AUDIT_POINTS', default: true),
     ],
 
     /*
@@ -131,12 +282,38 @@ return [
      */
     'freeze_duration' => env(key: 'STREAK_FREEZE_DURATION', default: 1),
 
+    /*
+    | -------------------------------------------------------------------------
+    | Tiers
+    | -------------------------------------------------------------------------
+    |
+    | Configure the tier system. Tiers provide named status brackets
+    | (e.g. Bronze, Silver, Gold) based on experience points.
+    |
+    */
     'tiers' => [
         'enabled' => env(key: 'TIERS_ENABLED', default: true),
         'demotion' => env(key: 'TIER_DEMOTION', default: false),
+
+        /*
+        | Tier-based streak freeze duration (in days). Map tier names
+        | to the number of days a streak can be frozen.
+        | Falls back to the global 'freeze_duration' if not set.
+        |
+        | Example: ['Bronze' => 1, 'Silver' => 2, 'Gold' => 3]
+        */
         'streak_freeze_days' => [],
     ],
 
+    /*
+    | -------------------------------------------------------------------------
+    | Challenges
+    | -------------------------------------------------------------------------
+    |
+    | Configure the challenges system. Challenges are multi-condition goals
+    | that users can enroll in and complete for rewards.
+    |
+    */
     'challenges' => [
         'enabled' => env(key: 'CHALLENGES_ENABLED', default: true),
     ],
@@ -752,7 +929,7 @@ Leaderboard::board('weekly-xp')
 
 Declarations are validated loudly at resolution rather than producing a silently wrong board: an unknown board name throws `BoardNotFoundException`, a missing or unknown `metric` throws `MetricNotFoundException`, a `period` declared for a non-Windowable metric (such as `level`) throws `MetricNotWindowableException`, an invalid `period` value throws a `ValueError`, and a `tier` name with no matching tier throws a `ModelNotFoundException`.
 
-Why declare a board instead of just querying? Boards are the leaderboards the package will **track over time** — snapshots, rank-change events, and leagues (arriving in later releases) apply only to declared Boards. Ad-hoc queries stay exactly what they are: composed, executed, forgotten. Declare no boards and none of that machinery activates.
+Why declare a board instead of just querying? Boards are the leaderboards the package **tracks over time** — snapshots, rank-change events, and leagues apply only to declared Boards. Ad-hoc queries stay exactly what they are: composed, executed, forgotten. Declare no boards and none of that machinery activates.
 
 ### Snapshots and rank events
 
@@ -888,7 +1065,7 @@ The semantics in detail:
 - **Ties split by standings order.** Cohort standings order by score, then by user key, so a tie straddling the promote or relegate boundary is resolved by that order — competition rank numbers (1, 1, 3) don't change how many users cross the line.
 - **Ghosts don't move.** A user who was never cohorted in the closed period keeps their Division and gets no event — relegation punishes losing, not absence.
 - **Idempotent.** Each rolled cohort is stamped with `rolled_over_at`; re-running the command for an already-rolled period is a no-op, so a scheduler double-fire is harmless.
-- **Movement lands next period.** The rollover records each mover's new Division but enrolls nobody — lazy enrollment places the user into a cohort of their new Division on their first earn of the new period. `currentDivision()` reflects the move immediately.
+- **Movement lands next period.** The rollover records each mover's new Division (as `next_division_id` on their cohort membership) but enrolls nobody — lazy enrollment places the user into a cohort of their new Division on their first earn of the new period. `currentDivision()` reflects the move immediately.
 
 Each movement dispatches a single event — mirroring the tier event grammar, with a direction enum instead of separate promoted/relegated classes:
 
@@ -899,6 +1076,44 @@ Each movement dispatches a single event — mirroring the tier event grammar, wi
 Non-movers and ghosts dispatch nothing.
 
 The `divisions`, `cohorts`, and `cohort_user` tables ship as package migrations — re-publish migrations and migrate when upgrading.
+
+### Recipes: what the package doesn't build
+
+The package owns the **ranking logic** — scores, ranks, ties, periods, snapshots, leagues. Display and app-specific queries belong to your application, and some "leaderboard" needs don't need leaderboard machinery at all. A few patterns:
+
+**Users ordered by raw XP.** If you just want users sorted by points — no rank numbers, no tie semantics, no time windows — one `orderByDesc` on the experiences table does it:
+
+```php
+use LevelUp\Experience\Models\Experience;
+
+$users = Experience::query()
+    ->with('user')
+    ->orderByDesc('experience_points')
+    ->limit(10)
+    ->get()
+    ->map(fn (Experience $experience) => $experience->user);
+```
+
+**Top-N boards are one-liners.** When you do want ranks and ties, compose metrics and periods instead of writing queries:
+
+```php
+Leaderboard::generate(limit: 10);                                 // top 10 by XP, all-time
+Leaderboard::by('xp')->period(Period::Week)->generate(limit: 10); // top 10 earners this week
+Leaderboard::by('achievements')->period(Period::Month)->generate(limit: 3); // this month's achievements podium
+```
+
+**Percentile / "top 10%" display.** Derive it from a rank and a total count — the package supplies the rank; your app defines the population:
+
+```php
+$rank = Leaderboard::rankOf(user: $user);
+$total = User::query()->whereHas('experience')->count();
+
+$topPercent = $rank === null ? null : (int) ceil($rank / $total * 100); // 4 → "top 4%"
+```
+
+**A friends board.** Your app owns the social graph; pass it through [`restrictTo()`](#friends-boards-and-custom-populations) and ranks are computed within the friend set — not filtered down from the global board.
+
+The package ships **no UI** — Blade views, Livewire components, and API resources for displaying any of this are deliberately your job.
 
 ## 🔍 Auditing
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,7 +2,7 @@
 
 ## v2.x -> v3.0
 
-v3.0 is a breaking-change release. Most users only need to run `composer require cjmellor/level-up:^3.0` then `php artisan migrate` — the multiplier schema reshape is backfilled automatically. Application code touching `Multiplier::scopeTo()` needs updating; the legacy `'table'` config key and the `UserForeignKey::on()` migration helper are gone.
+v3.0 is a breaking-change release, headlined by a metric-driven leaderboard: rank by any metric, time Periods, named Boards, Snapshots with rank events, and Leagues with Divisions and Cohorts. Most users only need to run `composer require cjmellor/level-up:^3.0`, re-publish migrations, then `php artisan migrate` — the multiplier schema reshape is backfilled automatically and the new leaderboard tables are created. Application code touching `Multiplier::scopeTo()` or consuming `Leaderboard::generate()` needs updating; the legacy `'table'` config key and the `UserForeignKey::on()` migration helper are gone.
 
 The boost skill `level-up-upgrade-v3` walks an LLM through this upgrade interactively if you're using boost.
 
@@ -86,6 +86,39 @@ Internal trait helpers like `experienceRelation()`, `challengesRelation()`, `str
 - Rename your method to avoid the collision (e.g. `userChallenges()`), or
 - Move the level-up traits onto a separate `UserProfile` / `Gamification` model and compose it onto User (same pattern Spatie's permission package uses).
 
+### `Leaderboard::generate()` returns `LeaderboardEntry` objects
+
+**Likelihood Of Impact: High** (if you use the leaderboard anywhere); **None** (if you don't).
+
+In v2.x, `Leaderboard::generate()` returned a collection of `User` models (with `experience` eager-loaded), ordered by points. In v3 every leaderboard query returns `LeaderboardEntry` objects — the user together with their score and rank. Score and rank live on the entry, never on the User model:
+
+```php
+// Before (v2.x)
+$users = Leaderboard::generate();
+
+foreach ($users as $user) {
+    $user->name;
+    $user->experience->experience_points;
+}
+
+// After (v3.0)
+$entries = Leaderboard::generate();
+
+foreach ($entries as $entry) {
+    $entry->user;  // the User model (experience still eager-loaded)
+    $entry->score; // the user's score on the board's metric
+    $entry->rank;  // competition rank — tied scores share a rank (1, 1, 3)
+}
+```
+
+`generate(paginate: true)` paginates entries the same way, and ranks are board-wide even when limiting or paginating. See the [Leaderboard section in the README](README.md#-leaderboard) for everything the query can now do — metrics, periods, `rankOf()` / `around()`, `restrictTo()`, Boards, Snapshots, and Leagues.
+
+### Leaderboard ranks require a window-function-capable database
+
+**Likelihood Of Impact: Low** (only outdated database versions are affected).
+
+v3 computes leaderboard ranks in the database with SQL window functions (`RANK() OVER`), so the leaderboard requires **SQLite 3.25+** or **MySQL 8+**; MariaDB 10.2+ and PostgreSQL support window functions natively. MySQL 5.7 (EOL) is not supported. Features that never run a leaderboard query are unaffected.
+
 ### Auditing is now enabled by default
 
 **Likelihood Of Impact: Medium** (every install that never published the config or never set `AUDIT_POINTS`).
@@ -147,8 +180,20 @@ The migration's `down()` previously generated invalid Postgres syntax (`ALTER CO
 ### Database compatibility
 
 - **PostgreSQL:** fully supported across all features, natively. The `MorphToManyWithTextCast` workaround from v2.1 is gone — schema is now Postgres-native.
-- **MySQL:** no behaviour change vs v2.1.
-- **SQLite:** ensure foreign-key enforcement is enabled (`PRAGMA foreign_keys = ON`) — Laravel's default does this, but verify if you've customised your `database.php` connection config.
+- **MySQL:** version 8+ is required for leaderboard rank queries (window functions — see above); MariaDB 10.2+ also works. No other behaviour change vs v2.1.
+- **SQLite:** version 3.25+ is required for leaderboard rank queries. Ensure foreign-key enforcement is enabled (`PRAGMA foreign_keys = ON`) — Laravel's default does this, but verify if you've customised your `database.php` connection config.
+
+### New: Leaderboards, Boards, Snapshots, and Leagues
+
+v3 ships the full leaderboard feature set: rank by any metric (`xp`, `level`, `streak`, `achievements`, `challenges`, or a custom `RankingMetric`), time Periods sourced from the audit ledger, `rankOf()` / `around()`, `restrictTo()` for friends boards and custom populations, named Boards declared in config, Snapshots with rank-change events, a `leaderboard_rank` challenge condition, and Leagues — a Division ladder with Cohorts, promotion, and relegation. See the [Leaderboard section in the README](README.md#-leaderboard).
+
+**New migrations required** — run `php artisan vendor:publish --tag="level-up-migrations"` then `php artisan migrate`:
+
+- `create_leaderboard_snapshots_table` — Snapshot storage for declared Boards
+- `create_divisions_table` — the league's Division ladder
+- `create_cohorts_table` and `create_cohort_user_table` — Cohort membership per Period
+
+All of it is opt-in: declare no Boards and no league, and only the live query API is active. Snapshots and league rollovers run via two independent commands — `level-up:snapshot-boards` and `level-up:league-rollover` — which you schedule from your application; the package never auto-registers scheduler entries.
 
 ## v1.x -> v2.0
 

--- a/config/level-up.php
+++ b/config/level-up.php
@@ -139,8 +139,8 @@ return [
     | the league machinery stays dormant. 'cohort_size' caps how many
     | users share a Cohort (default 30). 'divisions' is the ladder,
     | ordered bottom to top; each entry maps a Division name to its
-    | 'promote' and 'relegate' counts, which are read by the rollover
-    | (arriving in a later release). For example:
+    | 'promote' and 'relegate' counts, which are read by the
+    | level-up:league-rollover command at period close. For example:
     |
     | 'league' => [
     |     'board' => 'weekly-xp',

--- a/resources/boost/skills/level-up-development/SKILL.md
+++ b/resources/boost/skills/level-up-development/SKILL.md
@@ -115,7 +115,7 @@ $user->addPoints(50, multiplier: 2);
 $user->addPoints(50, type: AuditType::Add->value, reason: 'Bonus');
 ```
 
-Creates an experience record if none exists, otherwise increments. Automatically levels up if the threshold is crossed. Throws if the amount exceeds the highest level's `next_level_experience`.
+Creates an experience record if none exists, otherwise increments. Automatically levels up if the threshold is crossed. Points past the highest level's `next_level_experience` cap the user at the top level (no exception).
 
 ### Deduct Points
 
@@ -132,7 +132,7 @@ Throws `Exception` if the user has no experience record.
 $user->setPoints(500);
 ```
 
-Directly overwrites the XP total. Throws `Exception` if the user has no experience record.
+Directly overwrites the XP total, then recalculates level and tier from the new total (firing `UserLevelledUp` / `UserTierUpdated` as needed). Throws `Exception` if the user has no experience record. Writes no audit record — it is an administrative override, invisible to periodic leaderboards.
 
 ### Get Points
 
@@ -578,7 +578,7 @@ Leaderboard::rankOf(user: $user);               // Exact rank (int), null if abs
 Leaderboard::around(user: $user, range: 2);     // Up to 2 entries above + user + up to 2 below; empty if absent
 ```
 
-Returns `LeaderboardEntry` objects — `$entry->user` (with `experience` eager-loaded), `$entry->score`, and `$entry->rank` — ordered by score descending, then user key ascending. Ranks use competition semantics (tied scores share a rank; the next rank is skipped: 1, 1, 3) and are board-wide even when limiting or paginating. `rankOf()` and `around()` compose with `by()`, `period()`, `since()`, and `restrictTo()`. `restrictTo(Closure)` is the seam for host-defined populations the package can't know about (friends boards, guilds, tournament brackets): the closure narrows the base user query (`fn ($query) => $query->whereIn('id', $friendIds)`), and ranks are computed *within* the restricted set — rank 1 among friends, not the global rank filtered down. Like the other fluent state it is consumed by the terminal call, so the next board is global again. Ranks are computed with SQL window functions (requires SQLite 3.25+, MySQL 8+, or PostgreSQL). Metrics are registered in `level-up.leaderboard.metrics` (custom ones implement `LevelUp\Experience\Contracts\RankingMetric`); unknown keys throw `MetricNotFoundException`, disabled-feature metrics throw `MetricDisabledException`.
+Returns `LeaderboardEntry` objects — `$entry->user` (with `experience` eager-loaded), `$entry->score`, and `$entry->rank` — ordered by score descending, then user key ascending. Ranks use competition semantics (tied scores share a rank; the next rank is skipped: 1, 1, 3) and are board-wide even when limiting or paginating. `rankOf()` and `around()` compose with `by()`, `period()`, `since()`, and `restrictTo()`. `restrictTo(Closure)` is the seam for host-defined populations the package can't know about (friends boards, guilds, tournament brackets): the closure narrows the base user query (`fn ($query) => $query->whereIn('id', $friendIds)`), and ranks are computed *within* the restricted set — rank 1 among friends, not the global rank filtered down. Like the other fluent state it is consumed by the terminal call, so the next board is global again. Ranks are computed with SQL window functions (requires SQLite 3.25+, MySQL 8+ / MariaDB 10.2+, or PostgreSQL). Metrics are registered in `level-up.leaderboard.metrics` (custom ones implement `LevelUp\Experience\Contracts\RankingMetric`); unknown keys throw `MetricNotFoundException`, disabled-feature metrics throw `MetricDisabledException`.
 
 Built-in metrics: `xp` (experience points, the default), `level` (current level), `streak` (current streak count for an Activity), `achievements` (achievements earned), and `challenges` (challenges completed). `level` and `streak` are state metrics — they rank by a current snapshot, and users without the relevant record are absent from the board. The streak metric requires an Activity: construct the instance (`new StreakMetric(activity: $activity)`); using the bare `streak` registry key without one throws `MetricRequiresActivityException`.
 
@@ -775,11 +775,35 @@ return [
         'multiplier' => LevelUp\Experience\Models\Multiplier::class,
         'challenge' => LevelUp\Experience\Models\Challenge::class,
         'challenge_user' => LevelUp\Experience\Models\Pivots\ChallengeUser::class,
+        'leaderboard_snapshot' => LevelUp\Experience\Models\LeaderboardSnapshot::class,
+        'division' => LevelUp\Experience\Models\Division::class,
+        'cohort' => LevelUp\Experience\Models\Cohort::class,
     ],
     'user' => [
         'foreign_key' => 'user_id',
         'model' => App\Models\User::class,
         'users_table' => 'users',
+    ],
+    'leaderboard' => [
+        'default_metric' => 'xp',
+        'metrics' => [
+            'xp' => LevelUp\Experience\Metrics\ExperienceMetric::class,
+            'level' => LevelUp\Experience\Metrics\LevelMetric::class,
+            'streak' => LevelUp\Experience\Metrics\StreakMetric::class,
+            'achievements' => LevelUp\Experience\Metrics\AchievementMetric::class,
+            'challenges' => LevelUp\Experience\Metrics\ChallengeMetric::class,
+        ],
+        'boards' => [],
+        'snapshots' => [
+            'retention_days' => 30,
+        ],
+        'league' => [
+            'board' => null,
+            'cohort_size' => 30,
+            'divisions' => [],
+        ],
+        'week_starts_on' => Carbon\CarbonInterface::MONDAY,
+        'timezone' => null,
     ],
     'starting_level' => 1,
     'multiplier' => [
@@ -792,7 +816,7 @@ return [
         'points_continue' => env('LEVEL_CAP_POINTS_CONTINUE', true),
     ],
     'audit' => [
-        'enabled' => env('AUDIT_POINTS', false),
+        'enabled' => env('AUDIT_POINTS', true),
     ],
     'archive_streak_history' => [
         'enabled' => env('ARCHIVE_STREAK_HISTORY_ENABLED', true),

--- a/resources/boost/skills/level-up-upgrade-v3/SKILL.md
+++ b/resources/boost/skills/level-up-upgrade-v3/SKILL.md
@@ -11,7 +11,13 @@ If the user is on v1.x, run the `level-up-upgrade-v2` skill first, then come bac
 
 ## What's in v3
 
-A maintenance/cleanup release that:
+The headline is a metric-driven leaderboard: rank by any metric (`xp`, `level`, `streak`, `achievements`, `challenges`, or a custom `RankingMetric`), time Periods, `rankOf()`/`around()`, `restrictTo()` for friends boards, named Boards declared in config, Snapshots with rank-change events, a `leaderboard_rank` challenge condition, and Leagues (a Division ladder with Cohorts, promotion, and relegation). Three leaderboard breaking changes ride along:
+
+- `Leaderboard::generate()` returns `LeaderboardEntry` objects (`$entry->user`, `$entry->score`, `$entry->rank`) instead of a bare collection of `User` models.
+- `level-up.audit.enabled` defaults to `true` (was `false`) — periodic leaderboards source their scores from the `experience_audits` ledger.
+- Leaderboard ranks are computed with SQL window functions, requiring SQLite 3.25+ or MySQL 8+ (MariaDB 10.2+ and PostgreSQL support them natively).
+
+Plus cleanup:
 
 - Replaces the polymorphic `multiplier_scopes` table with two typed pivots — `multiplier_user` and `multiplier_tier`. Eliminates the need for v2.1's Postgres-specific morph-cast workaround.
 - Replaces `Multiplier::scopeTo($model)` with `scopeToUser($user)` / `scopeToTier($tier)` (plus `unscopeFromUser`, `unscopeFromTier`, `isGlobal`).
@@ -30,8 +36,9 @@ PHP and Laravel version requirements are unchanged (PHP 8.3+, Laravel 12 or 13).
 
 1. Confirm the user has backed up their database. The `multiplier_scopes` table will be transformed by a backfill migration — if anything goes wrong, they need a restore path.
 2. Confirm the user is on v2.x and not v1.x. If `composer show cjmellor/level-up | grep versions` shows v1.x, redirect to `level-up-upgrade-v2` first.
-3. Run `php artisan migrate:status` to ensure no pending migrations.
-4. Run `php artisan test` to ensure the test suite passes before starting.
+3. Check the database version if the app uses the leaderboard: ranks need window functions — SQLite 3.25+ or MySQL 8+ (MariaDB 10.2+ and PostgreSQL are fine). MySQL 5.7 cannot run v3 leaderboard queries.
+4. Run `php artisan migrate:status` to ensure no pending migrations.
+5. Run `php artisan test` to ensure the test suite passes before starting.
 
 ## Step 2: Update the composer constraint
 
@@ -134,13 +141,43 @@ If the host's User model defines any of `challenges()`, `streaks()`, `experience
 - Rename their User method (e.g. `userChallenges()`).
 - Move the level-up traits onto a separate `UserProfile` / `Gamification` model and compose it.
 
-## Step 11: Run migrations
+## Step 11: Update leaderboard consumers
+
+Search for `Leaderboard::`. Every terminal call (`generate()`, `around()`) now returns `LeaderboardEntry` objects instead of `User` models — update code that iterated users directly:
+
+```php
+// Before (v2.x)
+foreach (Leaderboard::generate() as $user) {
+    $user->name;
+    $user->experience->experience_points;
+}
+
+// After (v3.0)
+foreach (Leaderboard::generate() as $entry) {
+    $entry->user->name;  // the User model (experience still eager-loaded)
+    $entry->score;       // the user's score on the board's metric
+    $entry->rank;        // competition rank — tied scores share a rank (1, 1, 3)
+}
+```
+
+Blade templates, API resources, and tests that consumed the old shape need the same treatment.
+
+## Step 12: Decide on the audit default
+
+`level-up.audit.enabled` now defaults to `true`. Ask the user:
+
+- If they want time-windowed leaderboards (`period()` / `since()` on XP), auditing must stay on — and note that windowed boards only see activity recorded after auditing was enabled.
+- If they relied on the old default to keep `experience_audits` empty, set `AUDIT_POINTS=false` in `.env` — but periodic XP boards will then throw `MetricRequiresAuditingException`.
+- If their published config pins `'enabled' => env('AUDIT_POINTS', false)`, nothing changes until they update it.
+
+## Step 13: Publish and run migrations
 
 ```bash
+php artisan vendor:publish --tag="level-up-migrations"
 php artisan migrate
 ```
 
-The `migrate_multiplier_scopes_to_typed_pivots` migration runs automatically. If the user has existing `multiplier_scopes` data, it'll print a summary like:
+Publishing picks up the new leaderboard tables: `leaderboard_snapshots`, `divisions`, `cohorts`, and `cohort_user`. The `migrate_multiplier_scopes_to_typed_pivots` migration runs automatically. If the user has existing `multiplier_scopes` data, it'll print a summary like:
 
 ```
   level-up: migrated 47 multiplier scope rows (32 user, 15 tier) into typed pivot tables; dropped multiplier_scopes.
@@ -148,7 +185,7 @@ The `migrate_multiplier_scopes_to_typed_pivots` migration runs automatically. If
 
 If the migration encounters rows with a `scopeable_type` it doesn't recognise (not the configured user model and not the configured Tier class), it logs a warning and skips them — those rows are lost. Surface this to the user if it happens.
 
-## Step 12: Run tests
+## Step 14: Run tests
 
 ```bash
 php artisan test
@@ -156,7 +193,7 @@ php artisan test
 
 If anything fails, walk back through the steps above — most v3 breakage is straightforward find-and-replace.
 
-## Step 13: Verify
+## Step 15: Verify
 
 Spot-check that scoped multipliers still apply correctly:
 


### PR DESCRIPTION
Release-level documentation for the v3 leaderboard and leagues feature set, reconciling everything the individual feature PRs (#160–#170) shipped into one coherent story.

## What the docs now cover

**UPGRADE.md** — all three leaderboard breaking changes in one place for v2 users:

- `Leaderboard::generate()` returns `LeaderboardEntry` objects (`$entry->user`, `$entry->score`, `$entry->rank`) instead of bare `User` collections — with a before/after example.
- `level-up.audit.enabled` now defaults to `true`; flipping it back means periodic XP boards throw `MetricRequiresAuditingException`.
- Leaderboard ranks need a window-function-capable database: SQLite 3.25+ or MySQL 8+ (MariaDB 10.2+ and PostgreSQL support them natively).

Plus a new-features summary with the four new migrations (`leaderboard_snapshots`, `divisions`, `cohorts`, `cohort_user`) and updated database compatibility notes.

**CHANGELOG.md** — entries for the full feature set under v3.0.0-beta1: metrics contract, ranks and ties, state metrics, Periods, flow metrics, `restrictTo()`, named Boards, Snapshots and rank events, the `leaderboard_rank` challenge condition, Leagues, and the rollover — each referencing its PR (#160–#170).

**README** — a new "Recipes: what the package doesn't build" section showing the DIY patterns the package deliberately leaves to your app: ordering users by raw XP with one `orderByDesc`, top-N one-liners composed from metrics and periods, percentile / "top 10%" display derived from `rankOf()` plus a count, and friends boards via `restrictTo()`. The "published config file" block now matches the actual v3 config (it previously showed the pre-v3 config, including the old `audit.enabled => false` default and no leaderboard section).

**Consistency fixes** — leagues and the rollover are no longer described as "arriving in later releases" (README Boards intro, `config/level-up.php` league comment); the development boost skill no longer claims `addPoints()` throws past the top level (it caps since v3) and now documents `setPoints()` recalculation; the v3 upgrade boost skill now covers the leaderboard breaking changes with dedicated upgrade steps instead of calling v3 a maintenance release.

Stacked on #170 — the final slice of the v3 leaderboard batch.

Closes #158