### PR TITLE
docs: v3 documentation accuracy pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,11 @@ return [
         'multiplier_tier' => LevelUp\Experience\Models\Pivots\MultiplierTier::class,
         'challenge' => LevelUp\Experience\Models\Challenge::class,
         'challenge_user' => LevelUp\Experience\Models\Pivots\ChallengeUser::class,
+        'challenge_completion' => LevelUp\Experience\Models\ChallengeCompletion::class,
         'leaderboard_snapshot' => LevelUp\Experience\Models\LeaderboardSnapshot::class,
         'division' => LevelUp\Experience\Models\Division::class,
         'cohort' => LevelUp\Experience\Models\Cohort::class,
+        'cohort_user' => LevelUp\Experience\Models\Pivots\CohortUser::class,
     ],
 
     /*
@@ -131,6 +133,7 @@ return [
         'multiplier_tier' => 'multiplier_tier',
         'challenges' => 'challenges',
         'challenge_user' => 'challenge_user',
+        'challenge_completions' => 'challenge_completions',
         'leaderboard_snapshots' => 'leaderboard_snapshots',
         'divisions' => 'divisions',
         'cohorts' => 'cohorts',
@@ -825,7 +828,7 @@ Leaderboard::by('achievements')->period(Period::Week)->generate(); // most achie
 Leaderboard::by('challenges')->generate();                      // most challenges completed, ever
 ```
 
-`achievements` counts earned achievements; on a periodic board, only achievements earned within the window count. `challenges` counts **completed** challenges — being enrolled isn't enough — and periodic boards window on when each challenge was completed, not when the user enrolled. If the challenges system is turned off (`level-up.challenges.enabled`), the `challenges` metric throws `MetricDisabledException`. As with every metric, users with a count of zero are absent from the board rather than ranked at zero.
+`achievements` counts earned achievements; on a periodic board, only achievements earned within the window count. `challenges` counts **completions** recorded in the `challenge_completions` ledger — being enrolled isn't enough — so a [repeatable challenge](#repeatable-challenges) counts once per completion, and periodic boards window on when each completion happened, not when the user enrolled. If the challenges system is turned off (`level-up.challenges.enabled`), the `challenges` metric throws `MetricDisabledException`. As with every metric, users with a count of zero are absent from the board rather than ranked at zero.
 
 > [!NOTE]
 > The `achievements` count includes **secret** achievements. This is deliberate: a count reveals nothing about *which* achievements were earned, and excluding them would let users be punished on the leaderboard for earning a secret. Keep secrecy in what you display, not in the score.
@@ -1512,7 +1515,8 @@ Throws if the user is not enrolled, or if the challenge is already completed.
 
 ```php
 $user->activeChallenges;        // Enrolled, not yet completed
-$user->completedChallenges;     // Completed challenges
+$user->completedChallenges;     // Challenges completed at least once (distinct; repeatable-safe)
+$user->challengeCompletions;    // Every completion event (one row per completion, repeatable included)
 
 $user->getChallengeProgress($challenge);
 // Returns: [['type' => 'points_earned', 'completed' => true], ['type' => 'level_reached', 'completed' => false]]
@@ -1552,6 +1556,10 @@ Challenge::create([
 ### Repeatable Challenges
 
 Set `is_repeatable` to `true`. When all conditions are met, rewards are dispatched, then the challenge resets with a fresh baseline. The user can complete it again.
+
+Every completion — repeatable or not — is recorded as a row in the `challenge_completions` ledger, exposed as the `challengeCompletions()` relation on the user. A non-repeatable challenge contributes a single row; a repeatable challenge contributes one row per completion. This ledger is the source of truth for the [`challenges` leaderboard metric](#built-in-metrics), so repeated completions correctly increase a user's score and periodic challenge boards window on each completion's `completed_at`. The `completedChallenges` relation stays distinct — a challenge the user has finished appears there once, however many times it has been repeated.
+
+The `challenge_completions` table ships as a package migration — re-publish migrations and migrate when upgrading. The migration backfills one row per already-completed challenge, so existing completions are counted from the start.
 
 ### Events
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,7 +2,7 @@
 
 ## v2.x -> v3.0
 
-v3.0 is a breaking-change release, headlined by a metric-driven leaderboard: rank by any metric, time Periods, named Boards, Snapshots with rank events, and Leagues with Divisions and Cohorts. Most users only need to run `composer require cjmellor/level-up:^3.0`, re-publish migrations, then `php artisan migrate` — the multiplier schema reshape is backfilled automatically and the new leaderboard tables are created. Application code touching `Multiplier::scopeTo()` or consuming `Leaderboard::generate()` needs updating; the legacy `'table'` config key and the `UserForeignKey::on()` migration helper are gone.
+v3.0 is a breaking-change release, headlined by a metric-driven leaderboard: rank by any metric, time Periods, named Boards, Snapshots with rank events, and Leagues with Divisions and Cohorts. Most users only need to run `composer require cjmellor/level-up:^3.0`, re-publish migrations **and (if you previously published it) the config**, then `php artisan migrate` — the multiplier schema reshape and the new challenge-completion ledger are backfilled automatically, and the new leaderboard tables are created. If you use the new Boards or Leagues, declare them in config and schedule the two new commands. Application code touching `Multiplier::scopeTo()` or consuming `Leaderboard::generate()` needs updating; the legacy `'table'` config key and the `UserForeignKey::on()` migration helper are gone.
 
 The boost skill `level-up-upgrade-v3` walks an LLM through this upgrade interactively if you're using boost.
 
@@ -187,13 +187,35 @@ The migration's `down()` previously generated invalid Postgres syntax (`ALTER CO
 
 v3 ships the full leaderboard feature set: rank by any metric (`xp`, `level`, `streak`, `achievements`, `challenges`, or a custom `RankingMetric`), time Periods sourced from the audit ledger, `rankOf()` / `around()`, `restrictTo()` for friends boards and custom populations, named Boards declared in config, Snapshots with rank-change events, a `leaderboard_rank` challenge condition, and Leagues — a Division ladder with Cohorts, promotion, and relegation. See the [Leaderboard section in the README](README.md#-leaderboard).
 
+**Re-publish or merge the config — especially the `models` map.** Laravel merges a published config *shallowly*: any top-level array you already publish overrides the package default wholesale (it is not deep-merged). Installs that never published `config/level-up.php` pick up every new v3 default automatically and can skip this step.
+
+If you published the config in v1/v2, your `models` array overrides the package's, and model classes are resolved straight from `level-up.models.*` with no fallback — so the new bindings resolve to `null` and leagues, snapshots, and the challenge-completion ledger throw until you add them. Re-publish with `--force` (back up customisations first) or add these `models` keys by hand:
+
+```bash
+php artisan vendor:publish --tag="level-up-config" --force
+```
+
+- `multiplier_user` and `multiplier_tier` — the typed pivots that replace the removed `multiplier_scope` (you can drop that dead key).
+- `challenge_completion`, `leaderboard_snapshot`, `division`, `cohort`, and `cohort_user`.
+
+The new `leaderboard` settings block (`default_metric`, `metrics`, `boards`, `snapshots.retention_days`, `league`, plus top-level `week_starts_on` / `timezone`) is a brand-new top-level key, so it merges in from the package default automatically — but add it to your published file too so you can declare Boards or a league. Table names resolve through built-in defaults, so a stale `tables` array won't drop the new tables.
+
 **New migrations required** — run `php artisan vendor:publish --tag="level-up-migrations"` then `php artisan migrate`:
 
 - `create_leaderboard_snapshots_table` — Snapshot storage for declared Boards
 - `create_divisions_table` — the league's Division ladder
 - `create_cohorts_table` and `create_cohort_user_table` — Cohort membership per Period
+- `create_challenge_completions_table` — completion ledger behind the `challenges` metric; **backfilled automatically** from existing completed `challenge_user` pivots, so prior completions are counted
 
-All of it is opt-in: declare no Boards and no league, and only the live query API is active. Snapshots and league rollovers run via two independent commands — `level-up:snapshot-boards` and `level-up:league-rollover` — which you schedule from your application; the package never auto-registers scheduler entries.
+All of it is opt-in: declare no Boards and no league, and only the live query API is active. Snapshots and league rollovers run via two independent commands — `level-up:snapshot-boards` and `level-up:league-rollover` — which you schedule from your application; the package never auto-registers scheduler entries:
+
+```php
+// routes/console.php
+use Illuminate\Support\Facades\Schedule;
+
+Schedule::command('level-up:snapshot-boards')->daily();             // also prunes runs older than leaderboard.snapshots.retention_days
+Schedule::command('level-up:league-rollover')->weeklyOn(1, '00:05'); // align the cadence with your league board's Period
+```
 
 ## v1.x -> v2.0
 

--- a/resources/boost/skills/level-up-development/SKILL.md
+++ b/resources/boost/skills/level-up-development/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: level-up-development
-description: Build and work with cjmellor/level-up features, including XP, levels, tiers, achievements, streaks, multipliers, leaderboards, leagues, and auditing.
+description: Build and work with cjmellor/level-up features, including XP, levels, tiers, achievements, streaks, multipliers, challenges, leaderboards, leagues, and auditing.
 ---
 
 ## When to use this skill
@@ -519,8 +519,13 @@ Auto-enroll challenges (`auto_enroll: true`) automatically enroll users when a r
 $user->getChallengeProgress($challenge);              // Array of condition statuses
 $user->getChallengeCompletionPercentage($challenge);  // 0.0 - 100.0
 $user->activeChallenges;                              // Enrolled, not completed
-$user->completedChallenges;                           // Completed
+$user->completedChallenges;                           // Completed at least once (distinct; repeatable-safe)
+$user->challengeCompletions;                          // Every completion event (challenge_completions ledger)
 ```
+
+### Completion Ledger
+
+Every completion — repeatable or not — writes a row to the `challenge_completions` table (model `models.challenge_completion`), recorded by `ChallengeService::completeChallenge()`. This ledger is the source of truth for the `challenges` leaderboard metric, so a repeatable challenge completed N times counts N. `$user->challengeCompletions` is the raw feed (one row per completion); `$user->completedChallenges` stays distinct via `whereHas('completions')`, so a challenge appears there once no matter how many times it's repeated. The migration backfills one row per already-completed challenge on upgrade.
 
 ### Temporal Constraints
 
@@ -582,11 +587,11 @@ Returns `LeaderboardEntry` objects — `$entry->user` (with `experience` eager-l
 
 Built-in metrics: `xp` (experience points, the default), `level` (current level), `streak` (current streak count for an Activity), `achievements` (achievements earned), and `challenges` (challenges completed). `level` and `streak` are state metrics — they rank by a current snapshot, and users without the relevant record are absent from the board. The streak metric requires an Activity: construct the instance (`new StreakMetric(activity: $activity)`); using the bare `streak` registry key without one throws `MetricRequiresActivityException`.
 
-`achievements` and `challenges` are flow metrics (Windowable). `achievements` counts all earned achievements **including secret ones** — a count reveals nothing about which were earned; windowed boards count achievements earned within the period (pivot `created_at`). `challenges` counts completed challenges only (enrollment isn't enough); windowed boards window on the pivot `completed_at`. The `challenges` metric throws `MetricDisabledException` when `level-up.challenges.enabled` is off. For every metric, zero-count users are absent from the board, never ranked at 0.
+`achievements` and `challenges` are flow metrics (Windowable). `achievements` counts all earned achievements **including secret ones** — a count reveals nothing about which were earned; windowed boards count achievements earned within the period (pivot `created_at`). `challenges` counts completion rows in the `challenge_completions` ledger (one row per completion, so a repeatable challenge counts each time it's completed, not just once); windowed boards window on the ledger's `completed_at`. The `challenges` metric throws `MetricDisabledException` when `level-up.challenges.enabled` is off. For every metric, zero-count users are absent from the board, never ranked at 0.
 
 ### Time Periods
 
-`period(Period::Day|Week|Month)` and `since(start:, until:)` window a board to activity inside the range. For `xp` the windowed score is computed from the `experience_audits` ledger as `add` rows minus `remove` rows (state-change rows — `reset`, `level_up`, `tier_up`, `tier_down` — never count); this requires auditing (the v3 default), and with auditing explicitly disabled a periodic XP board throws `MetricRequiresAuditingException`. `achievements` and `challenges` window on their own pivot timestamps and don't need auditing. Only `Windowable` metrics support periods — `xp`, `achievements`, and `challenges` do; `level` and `streak` throw `MetricNotWindowableException`. Custom metrics opt in by implementing `LevelUp\Experience\Contracts\Windowable` (`windowedScoreExpression($start, $end)`; `$end` is `null` for an open-ended `since()`).
+`period(Period::Day|Week|Month)` and `since(start:, until:)` window a board to activity inside the range. For `xp` the windowed score is computed from the `experience_audits` ledger as `add` rows minus `remove` rows (state-change rows — `reset`, `level_up`, `tier_up`, `tier_down` — never count); this requires auditing (the v3 default), and with auditing explicitly disabled a periodic XP board throws `MetricRequiresAuditingException`. `achievements` and `challenges` window on their own timestamps (the achievement pivot's `created_at` and the `challenge_completions` ledger's `completed_at`) and don't need auditing. Only `Windowable` metrics support periods — `xp`, `achievements`, and `challenges` do; `level` and `streak` throw `MetricNotWindowableException`. Custom metrics opt in by implementing `LevelUp\Experience\Contracts\Windowable` (`windowedScoreExpression($start, $end)`; `$end` is `null` for an open-ended `since()`).
 
 `setPoints()` writes no audit record, so it never moves a periodic board (administrative override, not earned activity) — the all-time board sees it immediately. Users with no qualifying audit rows in the window are absent from the board. All-time boards (no period) read `experiences.experience_points` directly and never scan the ledger.
 
@@ -773,11 +778,15 @@ return [
         'achievement_user' => LevelUp\Experience\Models\Pivots\AchievementUser::class,
         'tier' => LevelUp\Experience\Models\Tier::class,
         'multiplier' => LevelUp\Experience\Models\Multiplier::class,
+        'multiplier_user' => LevelUp\Experience\Models\Pivots\MultiplierUser::class,
+        'multiplier_tier' => LevelUp\Experience\Models\Pivots\MultiplierTier::class,
         'challenge' => LevelUp\Experience\Models\Challenge::class,
         'challenge_user' => LevelUp\Experience\Models\Pivots\ChallengeUser::class,
+        'challenge_completion' => LevelUp\Experience\Models\ChallengeCompletion::class,
         'leaderboard_snapshot' => LevelUp\Experience\Models\LeaderboardSnapshot::class,
         'division' => LevelUp\Experience\Models\Division::class,
         'cohort' => LevelUp\Experience\Models\Cohort::class,
+        'cohort_user' => LevelUp\Experience\Models\Pivots\CohortUser::class,
     ],
     'user' => [
         'foreign_key' => 'user_id',

--- a/resources/boost/skills/level-up-upgrade-v3/SKILL.md
+++ b/resources/boost/skills/level-up-upgrade-v3/SKILL.md
@@ -28,6 +28,7 @@ Plus cleanup:
 - `addPoints()` past the highest level threshold now caps at the top level instead of throwing.
 - `addPoints()` is wrapped in `DB::transaction()` for atomicity.
 - `revokeAchievement()` clears the cached relation collection so subsequent reads see the detached state.
+- Adds a `challenge_completions` ledger — every completion is recorded as its own row, so the `challenges` leaderboard metric counts repeatable completions correctly; a migration backfills existing completions.
 - Fixes a Postgres rollback bug on `alter_experience_audits_type_to_string`.
 
 PHP and Laravel version requirements are unchanged (PHP 8.3+, Laravel 12 or 13).
@@ -170,14 +171,32 @@ Blade templates, API resources, and tests that consumed the old shape need the s
 - If they relied on the old default to keep `experience_audits` empty, set `AUDIT_POINTS=false` in `.env` — but periodic XP boards will then throw `MetricRequiresAuditingException`.
 - If their published config pins `'enabled' => env('AUDIT_POINTS', false)`, nothing changes until they update it.
 
-## Step 13: Publish and run migrations
+## Step 13: Add the new model bindings (if the config is published)
+
+The new league, snapshot, and challenge-completion features resolve their model classes straight from `level-up.models.*`, and Laravel merges a published config **shallowly** — so if the user published `config/level-up.php` in v1/v2, their `models` array overrides the package default and the new bindings are missing (they resolve to `null` and the feature throws). `tables` are safe (they fall back to built-in defaults) and the `leaderboard` settings block is a new top-level key that merges in automatically — it is specifically the `models` map that needs the additions.
+
+If `config/level-up.php` is **not** published, skip this step. If it **is**, add the new keys to the `models` array (or re-publish with `--force` after backing up customisations):
+
+```php
+'multiplier_user' => LevelUp\Experience\Models\Pivots\MultiplierUser::class,
+'multiplier_tier' => LevelUp\Experience\Models\Pivots\MultiplierTier::class,
+'challenge_completion' => LevelUp\Experience\Models\ChallengeCompletion::class,
+'leaderboard_snapshot' => LevelUp\Experience\Models\LeaderboardSnapshot::class,
+'division' => LevelUp\Experience\Models\Division::class,
+'cohort' => LevelUp\Experience\Models\Cohort::class,
+'cohort_user' => LevelUp\Experience\Models\Pivots\CohortUser::class,
+```
+
+The old `models.multiplier_scope` key (pointing at the removed `MultiplierScope`) is dead — drop it. To declare Boards or a league, also copy the new `leaderboard` block from the package's `config/level-up.php`.
+
+## Step 14: Publish and run migrations
 
 ```bash
 php artisan vendor:publish --tag="level-up-migrations"
 php artisan migrate
 ```
 
-Publishing picks up the new leaderboard tables: `leaderboard_snapshots`, `divisions`, `cohorts`, and `cohort_user`. The `migrate_multiplier_scopes_to_typed_pivots` migration runs automatically. If the user has existing `multiplier_scopes` data, it'll print a summary like:
+Publishing picks up the new v3 tables: `leaderboard_snapshots`, `divisions`, `cohorts`, `cohort_user`, and `challenge_completions`. The `migrate_multiplier_scopes_to_typed_pivots` migration runs automatically, and `create_challenge_completions_table` backfills the new ledger with one row per already-completed challenge (so the `challenges` metric counts prior completions). If the user has existing `multiplier_scopes` data, it'll print a summary like:
 
 ```
   level-up: migrated 47 multiplier scope rows (32 user, 15 tier) into typed pivot tables; dropped multiplier_scopes.
@@ -185,7 +204,7 @@ Publishing picks up the new leaderboard tables: `leaderboard_snapshots`, `divisi
 
 If the migration encounters rows with a `scopeable_type` it doesn't recognise (not the configured user model and not the configured Tier class), it logs a warning and skips them — those rows are lost. Surface this to the user if it happens.
 
-## Step 14: Run tests
+## Step 15: Run tests
 
 ```bash
 php artisan test
@@ -193,7 +212,7 @@ php artisan test
 
 If anything fails, walk back through the steps above — most v3 breakage is straightforward find-and-replace.
 
-## Step 15: Verify
+## Step 16: Verify
 
 Spot-check that scoped multipliers still apply correctly:
 


### PR DESCRIPTION
## Why

The `challenge_completions` ledger (#175) merged **after** the v3 documentation roll-up (#171/#174), so it ended up undocumented in the README, the v2→v3 upgrade guide, and the shipped Boost skills. While documenting it I also found a real upgrade footgun in how a previously-published config merges. This PR is a docs-only accuracy pass — no `src/` changes.

An audit of every other v3 leaderboard/leagues claim (metrics, boards, snapshots, leagues, events, commands, exceptions) against the code found the docs otherwise accurate; the gaps were concentrated entirely in the challenge-completions area.

## What changed

**README**
- Document the `challengeCompletions()` relation and explain repeatable-challenge ledger semantics in the Repeatable Challenges section.
- Clarify that the `challenges` metric counts **completions** from the ledger (so a repeatable challenge counts once per completion), not distinct challenges.
- Tighten the `completedChallenges` description (distinct / repeatable-safe).
- Sync the published-config snippet with the real `config/level-up.php`: `models.challenge_completion`, `models.cohort_user`, `tables.challenge_completions`.

**UPGRADE.md (v2 → v3)**
- List `create_challenge_completions_table` and its automatic backfill in the new-migrations section.
- Add a **"re-publish or merge the config"** step. Laravel merges a published config *shallowly*, so a config published in v1/v2 overrides the package's `models` map wholesale — and because model classes are resolved straight from `level-up.models.*` with no fallback, the new bindings (`division`, `cohort`, `cohort_user`, `leaderboard_snapshot`, `challenge_completion`, typed multiplier pivots) resolve to `null` and leagues/snapshots/completions throw until they're added. `tables` are safe (they fall back to built-in defaults) and the `leaderboard` block is a new top-level key that merges in fresh — the guide now says exactly that.
- Add a scheduler snippet for `level-up:snapshot-boards` / `level-up:league-rollover`.

**Boost skill `level-up-development`**
- Fix a correctness bug: the `challenges` metric description said it windows on the pivot `completed_at`; it reads the `challenge_completions` ledger.
- Add a Completion Ledger subsection and the `challengeCompletions` query line.
- Fill the four missing `models` keys (`multiplier_user`, `multiplier_tier`, `challenge_completion`, `cohort_user`) and add "challenges" to the skill description.

**Boost skill `level-up-upgrade-v3`**
- Add a step to add the new model bindings to a published config (the shallow-merge footgun above).
- Add `challenge_completions` + its backfill to the publish-migrations step.

**Deliberately left unchanged:** `level-up-upgrade-v2` — it pins `^2.0` and carries an "upgrading to v3? use the v3 skill" banner, so the `multiplier_scopes` table/model it references genuinely exist in the version it installs.