### PR TITLE
docs(v3): finalize changelog for v3.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to `level-up` will be documented in this file.
 
-## v3.0.0-beta1 - Unreleased
+## v3.0.0 - 2026-07-10
 
 ### Breaking changes
 


### PR DESCRIPTION
Drops the `-beta1`/Unreleased heading in favour of `v3.0.0 - 2026-07-10` now that the v3 line is feature-complete and ready to tag.